### PR TITLE
AO-1: Support multiple repos per plan

### DIFF
--- a/skills/planner/SKILL.md
+++ b/skills/planner/SKILL.md
@@ -66,7 +66,7 @@ Each plan is a directory under `<stateDir>/plans/`. The plan metadata lives in `
 | `name` | string | yes | Human-readable name. |
 | `createdAt` | string | yes | ISO 8601 timestamp. |
 | `createdBy` | string | yes | Who created this plan (e.g. `"planner"`). |
-| `repo` | string | yes | Absolute path to the target project repo. |
+| `repo` | string \| null | no | Default repo for tickets. `null` for multi-repo plans where each ticket specifies its own repo. |
 | `workflow` | string | yes | Workflow name (matches the `name` field in a workflow YAML file). |
 | `agent` | string \| null | no | Override default agent for all tickets in this plan. `null` uses the global default from `orchestrator.yaml`. |
 | `worktreeRoot` | string | yes | Absolute path where git worktrees will be created. |
@@ -121,7 +121,7 @@ Each plan is a directory under `<stateDir>/plans/`. The plan metadata lives in `
 | `description` | string | yes | Full description for the coding agent. Include enough context for the agent to implement the feature. |
 | `acceptanceCriteria` | string[] | yes | List of specific, testable criteria. The agent uses these to know when it's done. Defaults to `[]`. |
 | `linearUrl` | string \| null | yes | Link back to the source ticket. `null` if no external source. |
-| `repo` | string | yes | Absolute path to the target repo. Can override the plan-level `repo`. |
+| `repo` | string | yes | Absolute path to the target repo. Overrides the plan-level `repo` when set. Required on every ticket. |
 | `workflow` | string | yes | Workflow name. Can override the plan-level `workflow`. |
 | `branch` | string | yes | Git branch name. Convention: `<username>/<ticket-id>-<short-slug>`. |
 | `worktree` | string | yes | Absolute path for the git worktree. Convention: `<worktreeRoot>/<ticketId>`. |
@@ -322,6 +322,87 @@ A plan targeting a different repo with different workflows per ticket.
 }
 ```
 
+### Example 4: Multi-Repo Plan (Backend + Frontend)
+
+A plan that orchestrates work across two repositories. The plan-level `repo` is `null` because tickets target different repos.
+
+**Plan file** (`state/plans/cross-repo-auth/plan.json`):
+```json
+{
+  "id": "cross-repo-auth",
+  "name": "Cross-Repo — Auth Overhaul",
+  "createdAt": "2026-03-01T10:00:00Z",
+  "createdBy": "planner",
+  "repo": null,
+  "workflow": "standard",
+  "agent": null,
+  "worktreeRoot": "/Users/sam/worktrees",
+  "status": "active",
+  "tickets": [
+    { "ticketId": "AUTH-1", "order": 1, "blockedBy": [] },
+    { "ticketId": "AUTH-2", "order": 2, "blockedBy": ["AUTH-1"] }
+  ]
+}
+```
+
+**Backend ticket** (`state/plans/cross-repo-auth/tickets/AUTH-1.json`):
+```json
+{
+  "planId": "cross-repo-auth",
+  "ticketId": "AUTH-1",
+  "title": "Add OAuth2 endpoints to backend API",
+  "description": "Implement OAuth2 authorization code flow endpoints...",
+  "acceptanceCriteria": [
+    "GET /api/v1/auth/oauth/authorize redirects to provider",
+    "POST /api/v1/auth/oauth/callback exchanges code for tokens"
+  ],
+  "linearUrl": null,
+  "repo": "/Users/sam/repos/mindbloom-backend",
+  "workflow": "standard",
+  "branch": "sam/auth-1-oauth-endpoints",
+  "worktree": "/Users/sam/worktrees/AUTH-1",
+  "agent": null,
+  "status": "queued",
+  "currentPhase": "setup",
+  "phaseHistory": [],
+  "context": {},
+  "retries": {},
+  "error": null
+}
+```
+
+**Frontend ticket** (`state/plans/cross-repo-auth/tickets/AUTH-2.json`):
+```json
+{
+  "planId": "cross-repo-auth",
+  "ticketId": "AUTH-2",
+  "title": "Add OAuth2 login flow to frontend",
+  "description": "Implement the OAuth2 login button and callback handler in the frontend app...",
+  "acceptanceCriteria": [
+    "Login page shows 'Sign in with OAuth' button",
+    "Callback page exchanges code and stores session"
+  ],
+  "linearUrl": null,
+  "repo": "/Users/sam/repos/mindbloom-frontend",
+  "workflow": "standard",
+  "branch": "sam/auth-2-oauth-frontend",
+  "worktree": "/Users/sam/worktrees/AUTH-2",
+  "agent": null,
+  "status": "queued",
+  "currentPhase": "setup",
+  "phaseHistory": [],
+  "context": {},
+  "retries": {},
+  "error": null
+}
+```
+
+Key points for multi-repo plans:
+- Set plan-level `repo` to `null` when tickets target different repos.
+- Each ticket **must** have its own `repo` set to an absolute path.
+- `blockedBy` works across repos within the same plan — AUTH-2 waits for AUTH-1 even though they target different repos.
+- Each ticket gets its own worktree, branch, and workflow — these are always per-ticket.
+
 ## Naming Conventions
 
 - **Plan IDs**: lowercase, hyphenated slugs. Examples: `sprint-12-backend`, `hotfix-auth`, `mobile-sprint-4`.
@@ -334,7 +415,7 @@ A plan targeting a different repo with different workflows per ticket.
 1. Plan `id` matches the directory name.
 2. All `ticketId` values in the `tickets` array have matching `.json` files in `tickets/`.
 3. `blockedBy` references only ticket IDs that exist in the same plan.
-4. `repo` paths are absolute and point to actual repos.
+4. Every ticket has an absolute `repo` path pointing to an actual repo. Plan-level `repo` is either an absolute path or `null` for multi-repo plans.
 5. `worktreeRoot` is a writable directory.
 6. `workflow` names match actual workflow YAML files in the workflow directory.
 7. All new tickets have `status: "queued"`, `currentPhase` set to the workflow's first phase, and empty `phaseHistory`, `context`, `retries`.

--- a/src/core/runner.test.ts
+++ b/src/core/runner.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createRunner } from "./runner.js";
+import { createRunner, resolveTicketRepo } from "./runner.js";
 import type { OrchestratorConfig, PlanFile, TicketState } from "./types.js";
 
 describe("runner", () => {
@@ -649,6 +649,34 @@ phases:
     });
   });
 
+  describe("resolveTicketRepo", () => {
+    it("returns ticket unchanged when ticket has a repo", () => {
+      const ticket = makeTicket({ repo: "/repos/backend" });
+      const result = resolveTicketRepo(ticket, { repo: "/repos/default" });
+      expect(result.repo).toBe("/repos/backend");
+    });
+
+    it("inherits repo from plan when ticket repo is null", () => {
+      const ticket = makeTicket({ repo: null });
+      const result = resolveTicketRepo(ticket, { repo: "/repos/default" });
+      expect(result.repo).toBe("/repos/default");
+    });
+
+    it("throws when both ticket and plan repo are null", () => {
+      const ticket = makeTicket({ repo: null });
+      expect(() => resolveTicketRepo(ticket, { repo: null })).toThrow(
+        "has no repo and plan",
+      );
+    });
+
+    it("throws when ticket repo is null and plan is null", () => {
+      const ticket = makeTicket({ repo: null });
+      expect(() => resolveTicketRepo(ticket, null)).toThrow(
+        "has no repo and plan",
+      );
+    });
+  });
+
   describe("multi-repo plans", () => {
     it("executes tickets with different repos in a null-repo plan", async () => {
       await writeFile(
@@ -728,6 +756,24 @@ phases:
 
       const plan = makePlan({ repo: "/repos/my-project" });
       const ticket = makeTicket({ repo: "/repos/my-project" });
+      await savePlan(plan);
+      await saveTicket(ticket);
+
+      const runner = createRunner(config);
+      const result = await runner.runSingleTicket("test-plan", "TICKET-1");
+
+      expect(result.status).toBe("complete");
+    });
+
+    it("ticket with null repo inherits from plan repo", async () => {
+      await writeFile(
+        join(scriptDir, "run.sh"),
+        '#!/usr/bin/env bash\necho "ok"',
+        { mode: 0o755 },
+      );
+
+      const plan = makePlan({ repo: "/repos/my-project" });
+      const ticket = makeTicket({ repo: null });
       await savePlan(plan);
       await saveTicket(ticket);
 

--- a/src/core/runner.test.ts
+++ b/src/core/runner.test.ts
@@ -649,6 +649,95 @@ phases:
     });
   });
 
+  describe("multi-repo plans", () => {
+    it("executes tickets with different repos in a null-repo plan", async () => {
+      await writeFile(
+        join(scriptDir, "run.sh"),
+        '#!/usr/bin/env bash\necho "success output"',
+        { mode: 0o755 },
+      );
+
+      const plan = makePlan({
+        repo: null,
+        tickets: [
+          { ticketId: "TICKET-1", order: 1, blockedBy: [] },
+          { ticketId: "TICKET-2", order: 2, blockedBy: [] },
+        ],
+      });
+      await savePlan(plan);
+      await saveTicket(
+        makeTicket({ ticketId: "TICKET-1", repo: "/repos/backend" }),
+      );
+      await saveTicket(
+        makeTicket({ ticketId: "TICKET-2", repo: "/repos/frontend" }),
+      );
+
+      const runner = createRunner(config);
+      const r1 = await runner.runSingleTicket("test-plan", "TICKET-1");
+      const r2 = await runner.runSingleTicket("test-plan", "TICKET-2");
+
+      expect(r1.status).toBe("complete");
+      expect(r2.status).toBe("complete");
+    });
+
+    it("unblocks cross-repo tickets via dependencies", async () => {
+      await writeFile(
+        join(scriptDir, "run.sh"),
+        '#!/usr/bin/env bash\necho "ok"',
+        { mode: 0o755 },
+      );
+
+      const plan = makePlan({
+        repo: null,
+        tickets: [
+          { ticketId: "TICKET-1", order: 1, blockedBy: [] },
+          { ticketId: "TICKET-2", order: 2, blockedBy: ["TICKET-1"] },
+        ],
+      });
+      await savePlan(plan);
+      await saveTicket(
+        makeTicket({
+          ticketId: "TICKET-1",
+          repo: "/repos/backend",
+          status: "complete",
+        }),
+      );
+      await saveTicket(
+        makeTicket({
+          ticketId: "TICKET-2",
+          repo: "/repos/frontend",
+          status: "queued",
+        }),
+      );
+
+      const runner = createRunner(config);
+      await runner.tick();
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      const t2 = await readTicket("test-plan", "TICKET-2");
+      expect(["ready", "running", "complete"]).toContain(t2.status);
+    });
+
+    it("backward compat: plan with string repo still works", async () => {
+      await writeFile(
+        join(scriptDir, "run.sh"),
+        '#!/usr/bin/env bash\necho "ok"',
+        { mode: 0o755 },
+      );
+
+      const plan = makePlan({ repo: "/repos/my-project" });
+      const ticket = makeTicket({ repo: "/repos/my-project" });
+      await savePlan(plan);
+      await saveTicket(ticket);
+
+      const runner = createRunner(config);
+      const result = await runner.runSingleTicket("test-plan", "TICKET-1");
+
+      expect(result.status).toBe("complete");
+    });
+  });
+
   it("handles agent phase without promptTemplate gracefully", async () => {
     // Agent phase missing promptTemplate should fail and follow onFailure
     const agentWorkflowYaml = `

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -30,6 +30,20 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   });
 }
 
+export function resolveTicketRepo(
+  ticket: TicketState,
+  plan: { repo: string | null } | null,
+): TicketState {
+  if (ticket.repo) return ticket;
+  const resolved = plan?.repo ?? null;
+  if (!resolved) {
+    throw new Error(
+      `Ticket "${ticket.ticketId}" has no repo and plan "${ticket.planId}" has no default repo`,
+    );
+  }
+  return { ...ticket, repo: resolved };
+}
+
 export function createRunner(config: OrchestratorConfig): Runner {
   const stateManager = createStateManager(config.stateDir);
   const workflowLoader = createWorkflowLoader(config.workflowSearchPath);
@@ -44,6 +58,9 @@ export function createRunner(config: OrchestratorConfig): Runner {
   ): Promise<{ ticket: TicketState; pendingPoll: boolean }> {
     const plan = await stateManager.getPlan(ticket.planId);
     const planAgent = plan?.agent ?? null;
+
+    // Resolve ticket repo from plan if not set on the ticket
+    const resolved = resolveTicketRepo(ticket, plan);
 
     const phase = await workflowLoader.getPhase(
       ticket.workflow,
@@ -73,7 +90,7 @@ export function createRunner(config: OrchestratorConfig): Runner {
 
     let result: PhaseResult;
     try {
-      result = await phaseExecutor.execute(phase, ticket, planAgent);
+      result = await phaseExecutor.execute(phase, resolved, planAgent);
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       logger.phaseEnd(ticket.currentPhase, ticket.ticketId, "failure");

--- a/src/core/state.test.ts
+++ b/src/core/state.test.ts
@@ -220,6 +220,83 @@ describe("StateManager", () => {
     });
   });
 
+  describe("multi-repo plans", () => {
+    it("saves and retrieves a plan with null repo", async () => {
+      const sm = createStateManager(stateDir);
+      const plan = makePlan({ repo: null });
+      await sm.savePlan(plan);
+
+      const retrieved = await sm.getPlan("plan-1");
+      expect(retrieved).not.toBeNull();
+      expect(retrieved?.repo).toBeNull();
+    });
+
+    it("handles tickets with different repos in the same plan", async () => {
+      const sm = createStateManager(stateDir);
+      await sm.savePlan(makePlan({ repo: null }));
+      await sm.saveTicket(
+        makeTicket({ ticketId: "t-1", repo: "/repos/backend" }),
+      );
+      await sm.saveTicket(
+        makeTicket({ ticketId: "t-2", repo: "/repos/frontend" }),
+      );
+
+      const tickets = await sm.listTickets("plan-1");
+      expect(tickets).toHaveLength(2);
+
+      const repos = tickets.map((t) => t.repo).sort();
+      expect(repos).toEqual(["/repos/backend", "/repos/frontend"]);
+    });
+
+    it("resolves cross-repo dependencies within a plan", async () => {
+      const sm = createStateManager(stateDir);
+      await sm.savePlan(makePlan({ repo: null }));
+      await sm.saveTicket(
+        makeTicket({
+          ticketId: "t-1",
+          repo: "/repos/backend",
+          status: "complete",
+        }),
+      );
+      await sm.saveTicket(
+        makeTicket({
+          ticketId: "t-2",
+          repo: "/repos/frontend",
+          status: "queued",
+        }),
+      );
+
+      await sm.resolveDependencies("plan-1");
+
+      const ticket = await sm.getTicket("plan-1", "t-2");
+      expect(ticket?.status).toBe("ready");
+    });
+
+    it("getReadyTickets works with cross-repo tickets", async () => {
+      const sm = createStateManager(stateDir);
+      await sm.savePlan(makePlan({ repo: null }));
+      await sm.saveTicket(
+        makeTicket({
+          ticketId: "t-1",
+          repo: "/repos/backend",
+          status: "complete",
+        }),
+      );
+      await sm.saveTicket(
+        makeTicket({
+          ticketId: "t-2",
+          repo: "/repos/frontend",
+          status: "ready",
+        }),
+      );
+
+      const ready = await sm.getReadyTickets();
+      expect(ready).toHaveLength(1);
+      expect(ready[0].ticketId).toBe("t-2");
+      expect(ready[0].repo).toBe("/repos/frontend");
+    });
+  });
+
   describe("corrupted files", () => {
     it("returns null for corrupted plan file", async () => {
       const sm = createStateManager(stateDir);

--- a/src/core/types.test.ts
+++ b/src/core/types.test.ts
@@ -178,6 +178,22 @@ describe("PlanFileSchema", () => {
       PlanFileSchema.parse({ ...validPlan, status: "invalid" }),
     ).toThrow();
   });
+
+  it("defaults repo to null when omitted", () => {
+    const { repo, ...withoutRepo } = validPlan;
+    const result = PlanFileSchema.parse(withoutRepo);
+    expect(result.repo).toBeNull();
+  });
+
+  it("accepts explicit null repo for multi-repo plans", () => {
+    const result = PlanFileSchema.parse({ ...validPlan, repo: null });
+    expect(result.repo).toBeNull();
+  });
+
+  it("accepts a string repo for single-repo plans", () => {
+    const result = PlanFileSchema.parse(validPlan);
+    expect(result.repo).toBe("my-repo");
+  });
 });
 
 describe("WorkflowDefinitionSchema", () => {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -115,7 +115,7 @@ export const TicketStateSchema = z.object({
   description: z.string(),
   acceptanceCriteria: z.array(z.string()).default([]),
   linearUrl: z.string().nullable().default(null),
-  repo: z.string(),
+  repo: z.string().nullable().default(null),
   workflow: z.string(),
   branch: z.string(),
   worktree: z.string(),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -74,7 +74,7 @@ export const PlanFileSchema = z.object({
   name: z.string(),
   createdAt: z.string(),
   createdBy: z.string(),
-  repo: z.string(),
+  repo: z.string().nullable().default(null),
   workflow: z.string(),
   agent: z.string().nullable().default(null),
   worktreeRoot: z.string(),


### PR DESCRIPTION
## Summary

- Make `PlanFileSchema.repo` nullable (`string | null`, default `null`) so a single plan can orchestrate tickets targeting different repositories
- Each ticket's `repo` field serves as the source of truth for repo resolution; plan-level `repo` becomes an optional default
- Backward compatible — existing single-repo plans with a string `repo` continue to work unchanged

## Changes

- **`src/core/types.ts`** — `repo` field changed from `z.string()` to `z.string().nullable().default(null)`
- **`src/core/types.test.ts`** — Tests for null, string, and omitted repo parsing
- **`src/core/state.test.ts`** — Multi-repo state manager tests (save/retrieve null-repo plans, cross-repo dependency resolution, getReadyTickets)
- **`src/core/runner.test.ts`** — Multi-repo runner tests (cross-repo execution, dependency unblocking, backward compat)
- **`skills/planner/SKILL.md`** — Updated field docs, added multi-repo plan example (Example 4), updated validation rules

## Test plan

- [x] New tests for nullable repo in PlanFileSchema
- [x] New tests for multi-repo state management (save, list, resolve dependencies, getReadyTickets)
- [x] New tests for multi-repo runner execution (different repos, cross-repo deps, backward compat)
- [ ] Verify `pnpm run lint:fix && pnpm run typecheck && pnpm run test` passes

Closes https://github.com/linuxlewis/another-orchestrator/issues/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)