### PR TITLE
AO-2B: Route logs into the state directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ docs/                         # Reference documentation
 ~/.orchestrator/              # User data (external, created by `orchestrator init`)
   config.yaml                 # User configuration
   state/                      # Plan and ticket JSON files
-  logs/                       # Per-ticket execution logs
+    logs/                     # Per-ticket execution logs
 ```
 
 ## Key Source Files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ docs/                         # Reference documentation
 ~/.orchestrator/              # User data (external, created by `orchestrator init`)
   config.yaml                 # User configuration
   state/                      # Plan and ticket JSON files
-  logs/                       # Per-ticket execution logs
+    logs/                     # Per-ticket execution logs
 ```
 
 ## Key Source Files

--- a/README.md
+++ b/README.md
@@ -199,8 +199,7 @@ Config is created by `orchestrator init` at `~/.orchestrator/config.yaml`. The r
 
 **User data** (lives in `~/.orchestrator/`):
 - `config.yaml` -- agents, MCP servers, concurrency settings
-- `state/` -- plan and ticket JSON files
-- `logs/` -- execution logs
+- `state/` -- plan and ticket JSON files, plus `state/logs/` for execution logs
 
 Example config (directory fields are optional -- smart defaults apply):
 

--- a/mvp.md
+++ b/mvp.md
@@ -465,7 +465,7 @@ agent-orchestrator/
 │           └── SKILL.md
 │
 ├── state/                       # Runtime (gitignored)
-├── logs/                        # Per-ticket logs (gitignored)
+│   └── logs/                    # Per-ticket logs
 ├── schemas/                     # JSON schemas for validation
 │
 ├── CLAUDE.md                    # Project docs with progressive disclosure
@@ -563,7 +563,7 @@ All intervention is through file edits or CLI commands. No special tooling requi
 Three levels of visibility:
 
 1. **State files** — `cat state/<plan>/<ticket>.json | jq .currentPhase` for quick checks. The `phaseHistory` array shows the full execution trace.
-2. **Logs** — `tail -f logs/<ticketId>.log` for detailed agent output per ticket. Each phase logs its start, duration, exit code, and output summary.
+2. **Logs** — `tail -f state/logs/<ticketId>.log` for detailed agent output per ticket. Each phase logs its start, duration, exit code, and output summary.
 3. **Planner** — Ask the LLM planner "what's the status of everything?" and it reads the state files and summarizes. Can also identify stuck tickets, suggest retries, or flag issues.
 
 A future enhancement could add a TUI dashboard that watches the state directory and renders a live table.

--- a/skills/config/SKILL.md
+++ b/skills/config/SKILL.md
@@ -64,7 +64,8 @@ agents:
 
 # Optional: directory overrides (relative to config file location)
 # If omitted, smart defaults apply:
-#   stateDir, logDir → ~/.orchestrator/<name>
+#   stateDir → ~/.orchestrator/state
+#   logDir → <stateDir>/logs
 #   workflowDir, promptDir, scriptDir, skillsDir → bundled with package
 stateDir: ./state
 logDir: ./logs
@@ -108,7 +109,7 @@ Where plan and ticket JSON files are stored. Default: `~/.orchestrator/state`.
 
 ### `logDir` (string, optional)
 
-Where per-ticket execution logs are written. Default: `~/.orchestrator/logs`.
+Where per-ticket execution logs are written. Default: `<stateDir>/logs` (i.e., `~/.orchestrator/state/logs`).
 
 ### `workflowDir` (string, optional)
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -18,7 +18,8 @@ export function register(
       const targetDir = opts.dir
         ? resolve(opts.dir)
         : resolveOrchestratorHome();
-      await mkdir(join(targetDir, "state", "logs"), { recursive: true });
+      const logDir = join(targetDir, "state", "logs");
+      await mkdir(logDir, { recursive: true });
 
       const configPath = join(targetDir, "config.yaml");
       const configContent = `defaultAgent: claude
@@ -45,7 +46,7 @@ ghCommand: gh
         // File already exists, don't overwrite
       });
 
-      const logger = createLogger(join(targetDir, "state", "logs"));
+      const logger = createLogger(logDir);
       logger.success(`Initialized in ${targetDir}`);
       console.log(chalk.dim("  Created directories: state, state/logs"));
       console.log(chalk.dim(`  Config: ${configPath}`));

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -18,11 +18,7 @@ export function register(
       const targetDir = opts.dir
         ? resolve(opts.dir)
         : resolveOrchestratorHome();
-      const dirs = ["state", "logs"];
-
-      for (const dir of dirs) {
-        await mkdir(join(targetDir, dir), { recursive: true });
-      }
+      await mkdir(join(targetDir, "state", "logs"), { recursive: true });
 
       const configPath = join(targetDir, "config.yaml");
       const configContent = `defaultAgent: claude
@@ -49,9 +45,9 @@ ghCommand: gh
         // File already exists, don't overwrite
       });
 
-      const logger = createLogger(join(targetDir, "logs"));
+      const logger = createLogger(join(targetDir, "state", "logs"));
       logger.success(`Initialized in ${targetDir}`);
-      console.log(chalk.dim(`  Created directories: ${dirs.join(", ")}`));
+      console.log(chalk.dim("  Created directories: state, state/logs"));
       console.log(chalk.dim(`  Config: ${configPath}`));
     });
 }

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -171,7 +171,8 @@ describe("loadConfig", () => {
 
     // User data dirs default to home
     expect(config.stateDir).toBe(join(tmpDir, "home", "state"));
-    expect(config.logDir).toBe(join(tmpDir, "home", "logs"));
+    // logDir defaults to <stateDir>/logs
+    expect(config.logDir).toBe(join(tmpDir, "home", "state", "logs"));
 
     // Bundled dirs default to packageDir (except convention-based ones)
     expect(config.scriptDir).toBe(join(pkgDir, "scripts"));
@@ -192,6 +193,45 @@ describe("loadConfig", () => {
       join(tmpDir, "home", "workflows"),
       join(pkgDir, "workflows"),
     ]);
+  });
+
+  it("defaults logDir to <stateDir>/logs when not specified", async () => {
+    const configPath = join(tmpDir, "orchestrator.yaml");
+    await writeFile(
+      configPath,
+      `
+defaultAgent: claude
+agents:
+  claude:
+    command: claude
+    defaultArgs: []
+stateDir: ./my-state
+`,
+    );
+
+    const config = await loadConfig({ configPath, packageDir: pkgDir });
+    expect(config.stateDir).toBe(join(tmpDir, "my-state"));
+    expect(config.logDir).toBe(join(tmpDir, "my-state", "logs"));
+  });
+
+  it("respects explicit logDir override", async () => {
+    const configPath = join(tmpDir, "orchestrator.yaml");
+    await writeFile(
+      configPath,
+      `
+defaultAgent: claude
+agents:
+  claude:
+    command: claude
+    defaultArgs: []
+stateDir: ./my-state
+logDir: ./custom-logs
+`,
+    );
+
+    const config = await loadConfig({ configPath, packageDir: pkgDir });
+    expect(config.stateDir).toBe(join(tmpDir, "my-state"));
+    expect(config.logDir).toBe(join(tmpDir, "custom-logs"));
   });
 
   it("throws on invalid YAML", async () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -93,11 +93,13 @@ export async function loadConfig(
       ? [promptDir, bundledPromptDir]
       : [bundledPromptDir];
 
+  const stateDir = resolveDir(rawConfig.stateDir, join(home, "state"));
+
   const resolved: OrchestratorConfig = {
     ...rawConfig,
     // User data dirs default to ~/.orchestrator/<name>
-    stateDir: resolveDir(rawConfig.stateDir, join(home, "state")),
-    logDir: resolveDir(rawConfig.logDir, join(home, "logs")),
+    stateDir,
+    logDir: resolveDir(rawConfig.logDir, join(stateDir, "logs")),
     // Bundled dirs default to <packageDir>/<name>
     workflowDir,
     workflowSearchPath,


### PR DESCRIPTION
## Summary

- Default `logDir` to `<stateDir>/logs` instead of `~/.orchestrator/logs`, co-locating logs with plan and ticket state files
- Update `init` command to create `state/logs/` as a nested directory instead of a separate top-level `logs/` dir
- Add tests verifying logDir defaults to `<stateDir>/logs` and that explicit `logDir` overrides are still respected

## Changes

| File | What changed |
|------|-------------|
| `src/core/config.ts` | Derive `logDir` from resolved `stateDir` when not explicitly set |
| `src/commands/init.ts` | Create `state/logs/` instead of separate `state` and `logs` dirs |
| `src/core/config.test.ts` | Update existing test + add 2 new tests for logDir behavior |
| `CLAUDE.md`, `AGENTS.md` | Update project structure to show `logs/` nested under `state/` |
| `README.md` | Update user data section to reflect new log location |
| `mvp.md` | Update directory tree and observability docs |
| `skills/config/SKILL.md` | Update config reference for logDir default |

## Backward compatibility

If a user has explicitly set `logDir` in their `config.yaml`, that override still takes effect. Only the default changes.

Closes #2

## Test plan

- [x] Existing config tests updated and passing
- [x] New test: `logDir` defaults to `<stateDir>/logs` when not specified
- [x] New test: explicit `logDir` override is respected
- [ ] Run `pnpm run lint:fix && pnpm run typecheck && pnpm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)