### PR TITLE
AO-3: Fix logger timestamp showing month instead of minutes

### DIFF
--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -127,11 +127,12 @@ describe("createLogger", () => {
     const now = new Date();
     const expectedMinutes = String(now.getMinutes()).padStart(2, "0");
 
-    prettyStream.write(
-      `${JSON.stringify({ level: 30, time: Date.now(), msg: "ts-check" })}\n`,
-    );
-
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise<void>((resolve, reject) => {
+      prettyStream.write(
+        `${JSON.stringify({ level: 30, time: now.getTime(), msg: "ts-check" })}\n`,
+        (err) => (err ? reject(err) : resolve()),
+      );
+    });
 
     const output = chunks.join("");
     const timestampMatch = output.match(/(\d{2}):(\d{2}):(\d{2})/);

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -1,6 +1,8 @@
 import { readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Writable } from "node:stream";
+import pretty from "pino-pretty";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createLogger } from "./logger.js";
 
@@ -104,5 +106,38 @@ describe("createLogger", () => {
     const grandchild = child.child({ phase: "build" });
     expect(typeof grandchild.info).toBe("function");
     grandchild.info("nested log");
+  });
+
+  it("pretty-printed timestamp shows correct minutes, not month", async () => {
+    const chunks: string[] = [];
+    const sink = new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(chunk.toString());
+        callback();
+      },
+    });
+
+    const prettyStream = pretty({
+      colorize: false,
+      ignore: "pid,hostname",
+      translateTime: "SYS:HH:MM:ss",
+      destination: sink,
+    });
+
+    const now = new Date();
+    const expectedMinutes = String(now.getMinutes()).padStart(2, "0");
+
+    prettyStream.write(
+      `${JSON.stringify({ level: 30, time: Date.now(), msg: "ts-check" })}\n`,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const output = chunks.join("");
+    const timestampMatch = output.match(/(\d{2}):(\d{2}):(\d{2})/);
+    expect(timestampMatch).toBeTruthy();
+
+    const [, , minutesInOutput] = timestampMatch as RegExpMatchArray;
+    expect(minutesInOutput).toBe(expectedMinutes);
   });
 });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -11,7 +11,7 @@ export function createLogger(logDir: string): Logger {
   const prettyStream = pretty({
     colorize: true,
     ignore: "pid,hostname,ticketId",
-    translateTime: "SYS:HH:mm:ss",
+    translateTime: "SYS:HH:MM:ss",
     customLevels: "success:35",
     customColors: "success:green",
     messageFormat: (log: Record<string, unknown>, messageKey: string) => {


### PR DESCRIPTION
## Summary

- Fixed `translateTime` format string in `src/utils/logger.ts` from `"SYS:HH:mm:ss"` to `"SYS:HH:MM:ss"`
- The `dateformat` library (used by pino-pretty) treats `mm` as month and `MM` as minutes — opposite of moment.js convention
- Added test in `src/utils/logger.test.ts` that verifies pretty-printed timestamps show correct minutes

## Root Cause

The `dateformat` npm package used internally by pino-pretty has these tokens:
- `mm` → month (zero-padded, 01-12)
- `MM` → minutes (zero-padded, 00-59)

This caused timestamps to display month number in place of minutes (e.g., `11:03:10` instead of `11:04:10` during March).

## Test plan

- [x] Lint passes (`pnpm run lint:fix`)
- [x] Type check passes (`pnpm run typecheck`)
- [x] All 181 tests pass (`pnpm run test`)
- [x] New test verifies minutes appear correctly in formatted timestamp

Closes AO-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)