### PR TITLE
OI-1: Require user confirmation before writing plan files

### DIFF
--- a/skills/planner/SKILL.md
+++ b/skills/planner/SKILL.md
@@ -437,7 +437,7 @@ Options:
 
 ### Step 3: Handle the response
 
-- **User confirms** — Write `plan.json` and all ticket files to `<stateDir>/plans/<planId>/`. Then run through the checklist below.
+- **User confirms** — Write `plan.json` to `<stateDir>/plans/<planId>/` and all ticket files to `<stateDir>/plans/<planId>/tickets/`. Then run through the checklist below.
 - **User wants changes** — Ask what they want to change. Update the draft in conversation, present the revised JSON, and ask for confirmation again. Repeat until the user confirms.
 
 ### Why this matters

--- a/skills/planner/SKILL.md
+++ b/skills/planner/SKILL.md
@@ -10,7 +10,7 @@ You are the LLM planner for the Agent Orchestrator. Your job is to take work ite
 
 The orchestrator has two processes:
 
-1. **You (the planner)** — reason about tickets, dependencies, and priorities, then write JSON files to disk.
+1. **You (the planner)** — reason about tickets, dependencies, and priorities, draft the plan, get user confirmation, then write JSON files to disk.
 2. **The runner** — a deterministic state machine that reads those JSON files, walks a YAML workflow, and dispatches headless coding agents.
 
 The only interface between you and the runner is the `state/` directory. You write files. The runner reads and updates them. You never call each other directly.
@@ -409,6 +409,40 @@ Key points for multi-repo plans:
 - **Branch names**: `<username>/<ticket-id>-<short-slug>`. Examples: `sam/proj-101-password-reset`, `sam/mob-50-profile-avatar`.
 - **Worktree paths**: `<worktreeRoot>/<ticketId>`. Examples: `/Users/sam/worktrees/PROJ-101`.
 - **Ticket IDs**: match the source system's ID format. Keep them uppercase if the source uses uppercase (e.g., `PROJ-101`, `MOB-50`).
+
+## Plan Confirmation Workflow
+
+Before writing any files to the state directory, you **must** present the full plan to the user and get explicit confirmation. An active daemon may pick up new plan files immediately, so nothing should be written until the user has reviewed and approved.
+
+### Step 1: Draft the plan in conversation
+
+After gathering requirements (repo, workflow, agent, dependencies, etc.), build the complete plan and ticket JSON objects. Present them to the user directly in the conversation:
+
+1. Show the full `plan.json` content as a JSON code block.
+2. Show every ticket JSON (`<ticketId>.json`) as a separate JSON code block.
+3. Briefly summarize key details: number of tickets, dependency chain, workflow, agent, and target repos.
+
+### Step 2: Ask for explicit confirmation
+
+Use the `question` tool to ask the user to confirm the plan:
+
+```
+Question: "Ready to write this plan to disk?"
+Options:
+  - "Looks good, write it"
+  - "I want to make changes"
+```
+
+**Do not write any files until the user explicitly confirms.**
+
+### Step 3: Handle the response
+
+- **User confirms** — Write `plan.json` and all ticket files to `<stateDir>/plans/<planId>/`. Then run through the checklist below.
+- **User wants changes** — Ask what they want to change. Update the draft in conversation, present the revised JSON, and ask for confirmation again. Repeat until the user confirms.
+
+### Why this matters
+
+The runner daemon picks up new plan files on its next tick. Writing files before the user has reviewed the plan risks launching agents on unapproved work. Always confirm first.
 
 ## Checklist Before Submitting a Plan
 


### PR DESCRIPTION
## Summary

- Adds a **Plan Confirmation Workflow** section to `skills/planner/SKILL.md` that requires the LLM planner to present the full plan (plan.json + all ticket JSONs) in conversation before writing anything to disk.
- The planner must use the `question` tool to get explicit user confirmation before writing files to the state directory.
- If the user wants changes, the planner iterates on the draft in-conversation until confirmed.
- This prevents the runner daemon from picking up and executing unapproved plans.

## Test plan

- [ ] Verify the planner skill instructions correctly guide the LLM to draft plans in conversation first
- [ ] Verify the question tool is used to ask for confirmation before writing files
- [ ] Verify the iteration flow works when the user requests changes
- [ ] No TypeScript code changes — skill/prompt-only change

Closes OI-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)