### PR TITLE
OI-2: Kill running agent processes when a ticket or plan is paused

### DIFF
--- a/src/agents/invoke.ts
+++ b/src/agents/invoke.ts
@@ -53,6 +53,7 @@ export async function invokeAgent(
   agentConfig: AgentConfig,
   invocation: AgentInvocation,
   callbacks?: AgentCallbacks,
+  options?: { signal?: AbortSignal },
 ): Promise<AgentResult> {
   const { command, args } = buildAgentArgs(agentConfig, invocation);
 
@@ -60,6 +61,7 @@ export async function invokeAgent(
     cwd: invocation.cwd || undefined,
     timeoutMs: DEFAULT_TIMEOUT_MS,
     onStdout: callbacks?.onOutput,
+    signal: options?.signal,
   });
 
   return {

--- a/src/core/runner.test.ts
+++ b/src/core/runner.test.ts
@@ -649,6 +649,77 @@ phases:
     });
   });
 
+  describe("pause aborts in-flight agents", () => {
+    it("pausing a ticket on disk during execution stops the agent", async () => {
+      // Use a long-running script so we can pause mid-execution
+      await writeFile(
+        join(scriptDir, "run.sh"),
+        "#!/usr/bin/env bash\nsleep 30 && echo ok",
+        { mode: 0o755 },
+      );
+
+      const plan = makePlan();
+      const ticket = makeTicket({ status: "ready" });
+      await savePlan(plan);
+      await saveTicket(ticket);
+
+      const runner = createRunner({ ...config, pollInterval: 0.1 });
+
+      // Dispatch via tick
+      await runner.tick();
+
+      // Give fire-and-forget a moment to start
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Verify ticket is running
+      const running = await readTicket("test-plan", "TICKET-1");
+      expect(running.status).toBe("running");
+
+      // Pause the ticket on disk
+      await saveTicket({ ...running, status: "paused" });
+
+      // Next tick should detect the pause and abort the in-flight agent
+      await runner.tick();
+
+      // Give time for the abort to propagate and status to be written
+      await new Promise((r) => setTimeout(r, 500));
+
+      const final = await readTicket("test-plan", "TICKET-1");
+      expect(final.status).toBe("paused");
+    });
+
+    it("pausing a plan on disk during execution stops its tickets", async () => {
+      await writeFile(
+        join(scriptDir, "run.sh"),
+        "#!/usr/bin/env bash\nsleep 30 && echo ok",
+        { mode: 0o755 },
+      );
+
+      const plan = makePlan();
+      const ticket = makeTicket({ status: "ready" });
+      await savePlan(plan);
+      await saveTicket(ticket);
+
+      const runner = createRunner({ ...config, pollInterval: 0.1 });
+
+      // Dispatch via tick
+      await runner.tick();
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Pause the plan on disk
+      await savePlan({ ...plan, status: "paused" });
+
+      // Next tick should detect the pause and abort the in-flight agent
+      await runner.tick();
+
+      await new Promise((r) => setTimeout(r, 500));
+
+      const final = await readTicket("test-plan", "TICKET-1");
+      expect(final.status).toBe("paused");
+    });
+  });
+
   describe("resolveTicketRepo", () => {
     it("returns ticket unchanged when ticket has a repo", () => {
       const ticket = makeTicket({ repo: "/repos/backend" });

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -51,7 +51,12 @@ export function createRunner(config: OrchestratorConfig): Runner {
   const logger = createLogger(config.logDir);
   const phaseExecutor = createPhaseExecutor(config, templateRenderer, logger);
 
-  const inFlight = new Map<string, AbortController>();
+  interface InFlightEntry {
+    planId: string;
+    ticketId: string;
+    controller: AbortController;
+  }
+  const inFlight = new Map<string, InFlightEntry>();
 
   async function executeTicketPhase(
     ticket: TicketState,
@@ -377,7 +382,7 @@ export function createRunner(config: OrchestratorConfig): Runner {
 
       const key = `${planId}/${ticketId}`;
       const controller = new AbortController();
-      inFlight.set(key, controller);
+      inFlight.set(key, { planId, ticketId, controller });
 
       try {
         return await runTicketPhases(ticket, controller.signal);
@@ -396,8 +401,8 @@ export function createRunner(config: OrchestratorConfig): Runner {
       }
 
       // 2. Abort in-flight tickets whose on-disk status is now paused
-      for (const [key, controller] of inFlight) {
-        const [planId, ticketId] = key.split("/");
+      for (const [, entry] of inFlight) {
+        const { planId, ticketId, controller } = entry;
         const freshTicket = await stateManager.getTicket(planId, ticketId);
         const freshPlan = await stateManager.getPlan(planId);
         if (
@@ -405,8 +410,9 @@ export function createRunner(config: OrchestratorConfig): Runner {
           freshPlan?.status === "paused"
         ) {
           controller.abort();
-          // Ensure ticket is marked paused on disk immediately
-          if (freshTicket && freshTicket.status !== "paused") {
+          // Only mark paused if the ticket is still running to avoid
+          // overwriting a completed or failed status
+          if (freshTicket && freshTicket.status === "running") {
             await stateManager.updateTicket(planId, ticketId, {
               status: "paused",
             });
@@ -440,7 +446,11 @@ export function createRunner(config: OrchestratorConfig): Runner {
       for (const ticket of toDispatch) {
         const key = `${ticket.planId}/${ticket.ticketId}`;
         const controller = new AbortController();
-        inFlight.set(key, controller);
+        inFlight.set(key, {
+          planId: ticket.planId,
+          ticketId: ticket.ticketId,
+          controller,
+        });
 
         // Set status to running
         const running = await stateManager.updateTicket(

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -51,13 +51,32 @@ export function createRunner(config: OrchestratorConfig): Runner {
   const logger = createLogger(config.logDir);
   const phaseExecutor = createPhaseExecutor(config, templateRenderer, logger);
 
-  const inFlight = new Set<string>();
+  const inFlight = new Map<string, AbortController>();
 
   async function executeTicketPhase(
     ticket: TicketState,
+    signal?: AbortSignal,
   ): Promise<{ ticket: TicketState; pendingPoll: boolean }> {
     const log = logger.child({ ticketId: ticket.ticketId });
+
+    // Re-read ticket and plan status from disk before executing
+    const freshTicket = await stateManager.getTicket(
+      ticket.planId,
+      ticket.ticketId,
+    );
+    if (freshTicket?.status === "paused") {
+      return { ticket: freshTicket, pendingPoll: false };
+    }
     const plan = await stateManager.getPlan(ticket.planId);
+    if (plan?.status === "paused") {
+      const paused = await stateManager.updateTicket(
+        ticket.planId,
+        ticket.ticketId,
+        { status: "paused" },
+      );
+      return { ticket: paused, pendingPoll: false };
+    }
+
     const planAgent = plan?.agent ?? null;
 
     // Resolve ticket repo from plan if not set on the ticket
@@ -90,7 +109,19 @@ export function createRunner(config: OrchestratorConfig): Runner {
 
     let result: PhaseResult;
     try {
-      result = await phaseExecutor.execute(phase, resolved, planAgent);
+      result = await phaseExecutor.execute(phase, resolved, planAgent, {
+        signal,
+      });
+
+      // If aborted mid-phase, set ticket to paused and return early
+      if (signal?.aborted) {
+        const paused = await stateManager.updateTicket(
+          ticket.planId,
+          ticket.ticketId,
+          { status: "paused" },
+        );
+        return { ticket: paused, pendingPoll: false };
+      }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       log.error(`Phase "${ticket.currentPhase}" failed: ${errorMsg}`);
@@ -274,12 +305,27 @@ export function createRunner(config: OrchestratorConfig): Runner {
     return { ticket: updated, pendingPoll: false };
   }
 
-  async function runTicketPhases(ticket: TicketState): Promise<TicketState> {
+  async function runTicketPhases(
+    ticket: TicketState,
+    signal?: AbortSignal,
+  ): Promise<TicketState> {
     let current = ticket;
 
     while (true) {
-      const { ticket: updated, pendingPoll } =
-        await executeTicketPhase(current);
+      // Check if aborted before starting next phase
+      if (signal?.aborted) {
+        const paused = await stateManager.updateTicket(
+          current.planId,
+          current.ticketId,
+          { status: "paused" },
+        );
+        return paused;
+      }
+
+      const { ticket: updated, pendingPoll } = await executeTicketPhase(
+        current,
+        signal,
+      );
 
       // Re-read from disk for consistency
       const fromDisk = await stateManager.getTicket(
@@ -297,6 +343,7 @@ export function createRunner(config: OrchestratorConfig): Runner {
       if (
         current.status === "complete" ||
         current.status === "failed" ||
+        current.status === "paused" ||
         current.status === "needs_attention"
       ) {
         const log = logger.child({ ticketId: current.ticketId });
@@ -328,7 +375,15 @@ export function createRunner(config: OrchestratorConfig): Runner {
       const log = logger.child({ ticketId });
       log.info("Starting ticket");
 
-      return runTicketPhases(ticket);
+      const key = `${planId}/${ticketId}`;
+      const controller = new AbortController();
+      inFlight.set(key, controller);
+
+      try {
+        return await runTicketPhases(ticket, controller.signal);
+      } finally {
+        inFlight.delete(key);
+      }
     },
 
     async tick() {
@@ -340,13 +395,32 @@ export function createRunner(config: OrchestratorConfig): Runner {
         await stateManager.resolveDependencies(plan.id);
       }
 
-      // 2. Get current running count
+      // 2. Abort in-flight tickets whose on-disk status is now paused
+      for (const [key, controller] of inFlight) {
+        const [planId, ticketId] = key.split("/");
+        const freshTicket = await stateManager.getTicket(planId, ticketId);
+        const freshPlan = await stateManager.getPlan(planId);
+        if (
+          freshTicket?.status === "paused" ||
+          freshPlan?.status === "paused"
+        ) {
+          controller.abort();
+          // Ensure ticket is marked paused on disk immediately
+          if (freshTicket && freshTicket.status !== "paused") {
+            await stateManager.updateTicket(planId, ticketId, {
+              status: "paused",
+            });
+          }
+        }
+      }
+
+      // 3. Get current running count
       const runningCount = await stateManager.getRunningCount();
 
-      // 3. Get ready tickets
+      // 4. Get ready tickets
       const readyTickets = await stateManager.getReadyTickets();
 
-      // 4. Filter out tickets already in-flight or waiting on poll interval
+      // 5. Filter out tickets already in-flight or waiting on poll interval
       const now = Date.now();
       const dispatchable = readyTickets.filter((t) => {
         if (inFlight.has(`${t.planId}/${t.ticketId}`)) return false;
@@ -359,13 +433,14 @@ export function createRunner(config: OrchestratorConfig): Runner {
         return true;
       });
 
-      // 5. Dispatch up to available concurrency slots
+      // 6. Dispatch up to available concurrency slots
       const available = config.maxConcurrency - runningCount - inFlight.size;
       const toDispatch = dispatchable.slice(0, Math.max(0, available));
 
       for (const ticket of toDispatch) {
         const key = `${ticket.planId}/${ticket.ticketId}`;
-        inFlight.add(key);
+        const controller = new AbortController();
+        inFlight.set(key, controller);
 
         // Set status to running
         const running = await stateManager.updateTicket(
@@ -375,7 +450,7 @@ export function createRunner(config: OrchestratorConfig): Runner {
         );
 
         // Fire-and-forget
-        runTicketPhases(running)
+        runTicketPhases(running, controller.signal)
           .catch((err) => {
             const msg = err instanceof Error ? err.message : String(err);
             logger.child({ ticketId: ticket.ticketId }).error(`Failed: ${msg}`);
@@ -385,7 +460,7 @@ export function createRunner(config: OrchestratorConfig): Runner {
           });
       }
 
-      // 6. Log tick summary
+      // 7. Log tick summary
       logger.info(
         `Tick: dispatched=${toDispatch.length} running=${runningCount} ready=${readyTickets.length} inFlight=${inFlight.size}`,
       );

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -64,24 +64,7 @@ export function createRunner(config: OrchestratorConfig): Runner {
   ): Promise<{ ticket: TicketState; pendingPoll: boolean }> {
     const log = logger.child({ ticketId: ticket.ticketId });
 
-    // Re-read ticket and plan status from disk before executing
-    const freshTicket = await stateManager.getTicket(
-      ticket.planId,
-      ticket.ticketId,
-    );
-    if (freshTicket?.status === "paused") {
-      return { ticket: freshTicket, pendingPoll: false };
-    }
     const plan = await stateManager.getPlan(ticket.planId);
-    if (plan?.status === "paused") {
-      const paused = await stateManager.updateTicket(
-        ticket.planId,
-        ticket.ticketId,
-        { status: "paused" },
-      );
-      return { ticket: paused, pendingPoll: false };
-    }
-
     const planAgent = plan?.agent ?? null;
 
     // Resolve ticket repo from plan if not set on the ticket
@@ -118,14 +101,9 @@ export function createRunner(config: OrchestratorConfig): Runner {
         signal,
       });
 
-      // If aborted mid-phase, set ticket to paused and return early
+      // If aborted mid-phase, skip result processing
       if (signal?.aborted) {
-        const paused = await stateManager.updateTicket(
-          ticket.planId,
-          ticket.ticketId,
-          { status: "paused" },
-        );
-        return { ticket: paused, pendingPoll: false };
+        return { ticket, pendingPoll: false };
       }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
@@ -310,6 +288,30 @@ export function createRunner(config: OrchestratorConfig): Runner {
     return { ticket: updated, pendingPoll: false };
   }
 
+  async function markPausedIfNeeded(
+    current: TicketState,
+    signal?: AbortSignal,
+  ): Promise<TicketState | null> {
+    if (current.status === "paused") return current;
+
+    // Only running or ready tickets can be paused — don't overwrite terminal states
+    if (current.status !== "running" && current.status !== "ready") return null;
+
+    const shouldPause =
+      signal?.aborted ||
+      (await stateManager.getTicket(current.planId, current.ticketId))
+        ?.status === "paused" ||
+      (await stateManager.getPlan(current.planId))?.status === "paused";
+
+    if (shouldPause) {
+      return await stateManager.updateTicket(current.planId, current.ticketId, {
+        status: "paused",
+      });
+    }
+
+    return null;
+  }
+
   async function runTicketPhases(
     ticket: TicketState,
     signal?: AbortSignal,
@@ -317,15 +319,9 @@ export function createRunner(config: OrchestratorConfig): Runner {
     let current = ticket;
 
     while (true) {
-      // Check if aborted before starting next phase
-      if (signal?.aborted) {
-        const paused = await stateManager.updateTicket(
-          current.planId,
-          current.ticketId,
-          { status: "paused" },
-        );
-        return paused;
-      }
+      // Single pause checkpoint before each phase
+      const paused = await markPausedIfNeeded(current, signal);
+      if (paused) return paused;
 
       const { ticket: updated, pendingPoll } = await executeTicketPhase(
         current,
@@ -343,6 +339,10 @@ export function createRunner(config: OrchestratorConfig): Runner {
         );
       }
       current = fromDisk;
+
+      // Post-phase pause check (signal may have fired during execution)
+      const pausedAfter = await markPausedIfNeeded(current, signal);
+      if (pausedAfter) return pausedAfter;
 
       // Check if we reached a terminal or yielding state
       if (
@@ -404,19 +404,13 @@ export function createRunner(config: OrchestratorConfig): Runner {
       for (const [, entry] of inFlight) {
         const { planId, ticketId, controller } = entry;
         const freshTicket = await stateManager.getTicket(planId, ticketId);
-        const freshPlan = await stateManager.getPlan(planId);
-        if (
-          freshTicket?.status === "paused" ||
-          freshPlan?.status === "paused"
-        ) {
+        if (!freshTicket) continue;
+        const paused = await markPausedIfNeeded(freshTicket);
+        if (paused) {
+          logger
+            .child({ ticketId })
+            .info("Aborting in-flight ticket (paused on disk)");
           controller.abort();
-          // Only mark paused if the ticket is still running to avoid
-          // overwriting a completed or failed status
-          if (freshTicket && freshTicket.status === "running") {
-            await stateManager.updateTicket(planId, ticketId, {
-              status: "paused",
-            });
-          }
         }
       }
 

--- a/src/phases/executor.ts
+++ b/src/phases/executor.ts
@@ -25,6 +25,7 @@ export interface PhaseExecutor {
     phase: PhaseDefinition,
     ticket: TicketState,
     planAgent: string | null,
+    options?: { signal?: AbortSignal },
   ): Promise<PhaseResult>;
 }
 
@@ -42,6 +43,7 @@ export function createPhaseExecutor(
     phase: PhaseDefinition,
     ticket: TicketState,
     log: Logger,
+    signal?: AbortSignal,
   ): Promise<{ success: boolean; output: string }> {
     if (!phase.command) {
       return { success: false, output: "Script phase missing command" };
@@ -57,6 +59,7 @@ export function createPhaseExecutor(
     const result = await execCommand("/bin/bash", [scriptPath, ...args], {
       cwd: resolveCwd(ticket),
       timeoutMs: phase.timeoutSeconds ? phase.timeoutSeconds * 1000 : undefined,
+      signal,
     });
 
     if (result.stderr) {
@@ -117,6 +120,7 @@ export function createPhaseExecutor(
     ticket: TicketState,
     planAgent: string | null,
     log: Logger,
+    signal?: AbortSignal,
   ): Promise<PhaseResult> {
     if (!phase.promptTemplate) {
       return {
@@ -149,6 +153,7 @@ export function createPhaseExecutor(
       {
         onOutput: (chunk) => log.trace(chunk),
       },
+      { signal },
     );
 
     const captured = await captureValues(phase, agentResult.stdout, ticket);
@@ -166,6 +171,7 @@ export function createPhaseExecutor(
     phase: PhaseDefinition,
     ticket: TicketState,
     log: Logger,
+    signal?: AbortSignal,
   ): Promise<PhaseResult> {
     if (!phase.command) {
       return {
@@ -185,6 +191,7 @@ export function createPhaseExecutor(
 
     const result = await execCommand("/bin/bash", [scriptPath, ...args], {
       cwd: resolveCwd(ticket),
+      signal,
     });
 
     if (result.exitCode === 0) {
@@ -220,8 +227,9 @@ export function createPhaseExecutor(
     phase: PhaseDefinition,
     ticket: TicketState,
     log: Logger,
+    signal?: AbortSignal,
   ): Promise<PhaseResult> {
-    const { success, output } = await runScript(phase, ticket, log);
+    const { success, output } = await runScript(phase, ticket, log, signal);
     const captured = await captureValues(phase, output, ticket);
     const nextPhase = getNextPhase(phase, success);
 
@@ -229,17 +237,18 @@ export function createPhaseExecutor(
   }
 
   return {
-    async execute(phase, ticket, _planAgent) {
+    async execute(phase, ticket, _planAgent, options) {
       const log = logger.child({ ticketId: ticket.ticketId });
+      const signal = options?.signal;
       switch (phase.type) {
         case PhaseTypeSchema.enum.terminal:
           return executeTerminalPhase(phase);
         case PhaseTypeSchema.enum.agent:
-          return executeAgentPhase(phase, ticket, _planAgent, log);
+          return executeAgentPhase(phase, ticket, _planAgent, log, signal);
         case PhaseTypeSchema.enum.poll:
-          return executePollPhase(phase, ticket, log);
+          return executePollPhase(phase, ticket, log, signal);
         case PhaseTypeSchema.enum.script:
-          return executeScriptPhase(phase, ticket, log);
+          return executeScriptPhase(phase, ticket, log, signal);
         default: {
           const _exhaustive: never = phase.type;
           throw new Error(`Unknown phase type: ${_exhaustive}`);

--- a/src/utils/shell.test.ts
+++ b/src/utils/shell.test.ts
@@ -125,7 +125,7 @@ describe("shell", () => {
       setTimeout(() => controller.abort(), 100);
 
       const result = await promise;
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(130);
     });
 
     it("resolves immediately when AbortSignal is already aborted", async () => {
@@ -138,7 +138,7 @@ describe("shell", () => {
       });
       const elapsed = Date.now() - start;
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(130);
       expect(elapsed).toBeLessThan(2000);
     });
   });

--- a/src/utils/shell.test.ts
+++ b/src/utils/shell.test.ts
@@ -112,5 +112,34 @@ describe("shell", () => {
       expect(stdoutChunks.join("").trim()).toBe("out");
       expect(stderrChunks.join("").trim()).toBe("err");
     });
+
+    it("kills child process when AbortSignal is fired", async () => {
+      const controller = new AbortController();
+
+      // Start a long-running process
+      const promise = execCommandStreaming("sleep", ["10"], {
+        signal: controller.signal,
+      });
+
+      // Abort after a short delay
+      setTimeout(() => controller.abort(), 100);
+
+      const result = await promise;
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("resolves immediately when AbortSignal is already aborted", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const start = Date.now();
+      const result = await execCommandStreaming("sleep", ["10"], {
+        signal: controller.signal,
+      });
+      const elapsed = Date.now() - start;
+
+      expect(result.exitCode).toBe(1);
+      expect(elapsed).toBeLessThan(2000);
+    });
   });
 });

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -32,7 +32,7 @@ export function execCommandStreaming(
   options: StreamingOptions = {},
 ): Promise<ShellResult> {
   if (options.signal?.aborted) {
-    return Promise.resolve({ stdout: "", stderr: "", exitCode: 1 });
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 130 });
   }
 
   return new Promise((resolve) => {
@@ -83,12 +83,16 @@ export function execCommandStreaming(
         child.kill("SIGTERM");
       };
       options.signal.addEventListener("abort", onAbort, { once: true });
+      // Re-check after adding listener to close the race window
+      if (options.signal.aborted) {
+        onAbort();
+      }
     }
 
     child.on("close", (code) => {
       if (timer) clearTimeout(timer);
       if (aborted) {
-        resolve({ stdout, stderr, exitCode: 1 });
+        resolve({ stdout, stderr, exitCode: 130 });
         return;
       }
       resolve({

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -10,6 +10,7 @@ export interface ExecOptions {
   cwd?: string;
   env?: Record<string, string>;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }
 
 export interface StreamingOptions extends ExecOptions {
@@ -30,6 +31,10 @@ export function execCommandStreaming(
   args: string[] = [],
   options: StreamingOptions = {},
 ): Promise<ShellResult> {
+  if (options.signal?.aborted) {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 1 });
+  }
+
   return new Promise((resolve) => {
     let child: ReturnType<typeof spawn>;
     try {
@@ -71,8 +76,21 @@ export function execCommandStreaming(
       }, options.timeoutMs);
     }
 
+    let aborted = false;
+    if (options.signal) {
+      const onAbort = () => {
+        aborted = true;
+        child.kill("SIGTERM");
+      };
+      options.signal.addEventListener("abort", onAbort, { once: true });
+    }
+
     child.on("close", (code) => {
       if (timer) clearTimeout(timer);
+      if (aborted) {
+        resolve({ stdout, stderr, exitCode: 1 });
+        return;
+      }
       resolve({
         stdout,
         stderr: killed ? `${stderr}Process timed out` : stderr,

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -80,6 +80,9 @@ export function execCommandStreaming(
     if (options.signal) {
       const onAbort = () => {
         aborted = true;
+        options.onStderr?.(
+          `Killing child process (pid=${child.pid}) via abort signal\n`,
+        );
         child.kill("SIGTERM");
       };
       options.signal.addEventListener("abort", onAbort, { once: true });


### PR DESCRIPTION
## Summary

When `pause` or `pause-plan` is run via the CLI, the daemon now immediately kills any in-flight agent processes for the affected tickets. Previously, the ticket/plan status was updated on disk but spawned child processes kept running until the daemon was restarted.

## Changes

- **`src/utils/shell.ts`** — Accept an optional `AbortSignal` in `StreamingOptions`. When the signal fires, send `SIGTERM` to the child process and resolve. Handle already-aborted signals immediately.
- **`src/agents/invoke.ts`** — Accept an optional `AbortSignal` and pass it through to `execCommandStreaming`.
- **`src/phases/executor.ts`** — Thread `AbortSignal` through all phase executors (agent, script, poll).
- **`src/core/runner.ts`** — Store an `AbortController` per in-flight ticket in a `Map<string, AbortController>`. On each `tick()`, scan in-flight tickets and abort any whose on-disk status (or parent plan status) is `paused`. Thread the signal through `runTicketPhases` → `executeTicketPhase` → `phaseExecutor.execute`. Re-read ticket/plan status before each phase execution for early exit. Clean up controllers in `.finally()`.
- **`src/utils/shell.test.ts`** — Tests for AbortSignal killing child processes (both mid-execution and pre-aborted).
- **`src/core/runner.test.ts`** — Tests for pausing a ticket and pausing a plan during execution, verifying the in-flight agent is killed and the ticket ends in `paused` status.

## Test plan

- [x] `pnpm run test` — all tests pass including new abort/pause tests
- [x] `pnpm run typecheck` — no type errors
- [x] `pnpm run lint:fix` — no lint issues

Resolves OI-2