### PR TITLE
CST-001: Track Claude session IDs with list/resume CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ All commands accept `-C, --config <path>` to use a specific config file.
 | `orchestrator retry <planId> <ticketId>` | Reset retries and re-run the current phase |
 | `orchestrator pause-plan <planId>` | Pause an entire plan |
 | `orchestrator resume-plan <planId>` | Resume a paused plan |
+| `orchestrator sessions <planId> <ticketId> [--phase <phase>] [--json]` | List Claude sessions for a ticket |
+| `orchestrator resume-session <planId> <ticketId> [sessionId] [--phase <phase>]` | Resume a Claude session interactively |
 
 ## Architecture
 
@@ -138,6 +140,29 @@ The coding agent is configurable at four levels (highest priority first):
 4. **Global default** -- `defaultAgent` in config
 
 Each invocation is a subprocess in the ticket's git worktree. The agent reads the target project's own CLAUDE.md/AGENTS.md for repo-specific knowledge (how to test, lint, build).
+
+### Session Tracking
+
+When the orchestrator dispatches a Claude agent phase, it captures the session ID from Claude's JSON output. Session IDs are persisted in each ticket's `phaseHistory` entries and logged to both the console and the log file.
+
+Users can list all Claude sessions for a ticket and resume any session interactively:
+
+```sh
+# List all Claude sessions for a ticket
+orchestrator sessions <planId> <ticketId>
+
+# Filter sessions by phase
+orchestrator sessions <planId> <ticketId> --phase implement
+
+# Resume the most recent session
+orchestrator resume-session <planId> <ticketId>
+
+# Resume a specific session
+orchestrator resume-session <planId> <ticketId> cc807f8c-1234-5678-abcd-ef0123456789
+
+# Resume the most recent session from a specific phase
+orchestrator resume-session <planId> <ticketId> --phase self_review
+```
 
 ## Project Structure
 

--- a/src/agents/invoke.test.ts
+++ b/src/agents/invoke.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildAgentArgs, invokeAgent } from "./invoke.js";
+import {
+  buildAgentArgs,
+  invokeAgent,
+  parseClaudeJsonOutput,
+} from "./invoke.js";
 
 describe("buildAgentArgs", () => {
   it("builds args for claude agent", () => {
@@ -13,7 +17,7 @@ describe("buildAgentArgs", () => {
       "-p",
       "fix the bug",
       "--output-format",
-      "text",
+      "json",
       "--verbose",
     ]);
   });
@@ -57,6 +61,39 @@ describe("buildAgentArgs", () => {
 
     expect(result.command).toBe("my-agent");
     expect(result.args).toEqual(["hello", "--flag"]);
+  });
+});
+
+describe("parseClaudeJsonOutput", () => {
+  it("extracts result and session_id from valid JSON", () => {
+    const raw = JSON.stringify({
+      result: "Hello world",
+      session_id: "abc-123",
+    });
+    const parsed = parseClaudeJsonOutput(raw);
+    expect(parsed.text).toBe("Hello world");
+    expect(parsed.sessionId).toBe("abc-123");
+  });
+
+  it("extracts result without session_id", () => {
+    const raw = JSON.stringify({ result: "Some output" });
+    const parsed = parseClaudeJsonOutput(raw);
+    expect(parsed.text).toBe("Some output");
+    expect(parsed.sessionId).toBeUndefined();
+  });
+
+  it("falls back to raw string on invalid JSON", () => {
+    const raw = "not valid json";
+    const parsed = parseClaudeJsonOutput(raw);
+    expect(parsed.text).toBe("not valid json");
+    expect(parsed.sessionId).toBeUndefined();
+  });
+
+  it("falls back to raw string when result field is missing", () => {
+    const raw = JSON.stringify({ session_id: "abc-123", other: "data" });
+    const parsed = parseClaudeJsonOutput(raw);
+    expect(parsed.text).toBe(raw);
+    expect(parsed.sessionId).toBe("abc-123");
   });
 });
 

--- a/src/agents/invoke.ts
+++ b/src/agents/invoke.ts
@@ -13,6 +13,7 @@ export interface AgentResult {
   stderr: string;
   exitCode: number;
   success: boolean;
+  sessionId?: string;
 }
 
 export interface AgentCallbacks {
@@ -29,7 +30,7 @@ export function buildAgentArgs(
   const { prompt, allowedTools, maxTurns } = invocation;
 
   if (command === "claude") {
-    const args = ["-p", prompt, "--output-format", "text", ...defaultArgs];
+    const args = ["-p", prompt, "--output-format", "json", ...defaultArgs];
     if (allowedTools?.length) {
       args.push("--allowedTools", ...allowedTools);
     }
@@ -49,6 +50,21 @@ export function buildAgentArgs(
   return { command, args };
 }
 
+export function parseClaudeJsonOutput(raw: string): {
+  text: string;
+  sessionId?: string;
+} {
+  try {
+    const json = JSON.parse(raw);
+    const text = typeof json.result === "string" ? json.result : raw;
+    const sessionId =
+      typeof json.session_id === "string" ? json.session_id : undefined;
+    return { text, sessionId };
+  } catch {
+    return { text: raw };
+  }
+}
+
 export async function invokeAgent(
   agentConfig: AgentConfig,
   invocation: AgentInvocation,
@@ -63,6 +79,17 @@ export async function invokeAgent(
     onStdout: callbacks?.onOutput,
     signal: options?.signal,
   });
+
+  if (agentConfig.command === "claude") {
+    const parsed = parseClaudeJsonOutput(result.stdout);
+    return {
+      stdout: parsed.text,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+      success: result.exitCode === 0,
+      sessionId: parsed.sessionId,
+    };
+  }
 
   return {
     stdout: result.stdout,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { Command } from "commander";
 import { register as registerInit } from "./commands/init.js";
 import { register as registerInteractive } from "./commands/interactive.js";
 import { register as registerRun } from "./commands/run.js";
+import { register as registerSessions } from "./commands/sessions.js";
 import { register as registerStatus } from "./commands/status.js";
 import { register as registerTickets } from "./commands/tickets.js";
 import type { LoadConfigOptions } from "./core/config.js";
@@ -27,6 +28,7 @@ registerInit(program, getConfigOptions);
 registerStatus(program, getConfigOptions);
 registerRun(program, getConfigOptions);
 registerTickets(program, getConfigOptions);
+registerSessions(program, getConfigOptions);
 registerInteractive(program, getConfigOptions);
 
 program.parse();

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,0 +1,140 @@
+import chalk from "chalk";
+import type { Command } from "commander";
+import { spawnInteractive } from "../agents/interactive.js";
+import type { LoadConfigOptions } from "../core/config.js";
+import { loadConfig } from "../core/config.js";
+import { createStateManager } from "../core/state.js";
+
+export function register(
+  program: Command,
+  getConfigOptions: () => LoadConfigOptions,
+): void {
+  program
+    .command("sessions")
+    .description("List Claude sessions for a ticket")
+    .argument("<planId>", "Plan ID")
+    .argument("<ticketId>", "Ticket ID")
+    .option("--phase <phase>", "Filter by phase name")
+    .option("--json", "Output as JSON")
+    .action(
+      async (
+        planId: string,
+        ticketId: string,
+        opts: { phase?: string; json?: boolean },
+      ) => {
+        const config = await loadConfig(getConfigOptions());
+        const state = createStateManager(config.stateDir);
+        const ticket = await state.getTicket(planId, ticketId);
+
+        if (!ticket) {
+          console.error(chalk.red(`Ticket "${ticketId}" not found`));
+          process.exitCode = 1;
+          return;
+        }
+
+        let sessions = ticket.phaseHistory.filter((h) => h.sessionId);
+
+        if (opts.phase) {
+          sessions = sessions.filter((h) => h.phase === opts.phase);
+        }
+
+        if (sessions.length === 0) {
+          console.log("No Claude sessions found for this ticket.");
+          return;
+        }
+
+        if (opts.json) {
+          const output = sessions.map((s) => ({
+            phase: s.phase,
+            status: s.status,
+            startedAt: s.startedAt,
+            completedAt: s.completedAt,
+            sessionId: s.sessionId,
+          }));
+          console.log(JSON.stringify(output, null, 2));
+          return;
+        }
+
+        for (let i = 0; i < sessions.length; i++) {
+          const s = sessions[i];
+          const statusColor =
+            s.status === "success"
+              ? chalk.green(s.status)
+              : chalk.red(s.status);
+          console.log(
+            `${i + 1}. ${chalk.cyan(s.phase)} ${statusColor} ${chalk.dim(s.startedAt)} ${chalk.yellow(s.sessionId)}`,
+          );
+        }
+
+        console.log();
+        console.log(
+          `Resume a session with: orchestrator resume-session ${planId} ${ticketId} <session-id>`,
+        );
+      },
+    );
+
+  program
+    .command("resume-session")
+    .description("Resume a Claude session interactively")
+    .argument("<planId>", "Plan ID")
+    .argument("<ticketId>", "Ticket ID")
+    .argument("[sessionId]", "Session ID to resume (defaults to most recent)")
+    .option(
+      "--phase <phase>",
+      "Pick the most recent session from a specific phase",
+    )
+    .action(
+      async (
+        planId: string,
+        ticketId: string,
+        sessionIdArg: string | undefined,
+        opts: { phase?: string },
+      ) => {
+        const config = await loadConfig(getConfigOptions());
+        const state = createStateManager(config.stateDir);
+        const ticket = await state.getTicket(planId, ticketId);
+
+        if (!ticket) {
+          console.error(chalk.red(`Ticket "${ticketId}" not found`));
+          process.exitCode = 1;
+          return;
+        }
+
+        let sessionId = sessionIdArg;
+
+        if (!sessionId) {
+          let sessions = ticket.phaseHistory.filter((h) => h.sessionId);
+          if (opts.phase) {
+            sessions = sessions.filter((h) => h.phase === opts.phase);
+          }
+          const latest = sessions[sessions.length - 1];
+          sessionId = latest?.sessionId;
+        }
+
+        if (!sessionId) {
+          console.error(
+            chalk.red(
+              "No session ID found. Provide one explicitly or check the ticket has Claude sessions.",
+            ),
+          );
+          process.exitCode = 1;
+          return;
+        }
+
+        const cwd = ticket.worktree || process.cwd();
+
+        console.log(`Session: ${chalk.yellow(sessionId)}`);
+        console.log(`Ticket:  ${chalk.cyan(ticketId)}`);
+        console.log(`CWD:     ${chalk.dim(cwd)}`);
+        console.log();
+
+        const exitCode = await spawnInteractive({
+          command: "claude",
+          args: ["--resume", sessionId],
+          cwd,
+        });
+
+        process.exitCode = exitCode;
+      },
+    );
+}

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -4,6 +4,20 @@ import { spawnInteractive } from "../agents/interactive.js";
 import type { LoadConfigOptions } from "../core/config.js";
 import { loadConfig } from "../core/config.js";
 import { createStateManager } from "../core/state.js";
+import type { PhaseHistoryEntry, TicketState } from "../core/types.js";
+
+const SESSION_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function getClaudeSessions(
+  ticket: TicketState,
+  phase?: string,
+): PhaseHistoryEntry[] {
+  let sessions = ticket.phaseHistory.filter((h) => h.sessionId);
+  if (phase) {
+    sessions = sessions.filter((h) => h.phase === phase);
+  }
+  return sessions;
+}
 
 export function register(
   program: Command,
@@ -32,11 +46,7 @@ export function register(
           return;
         }
 
-        let sessions = ticket.phaseHistory.filter((h) => h.sessionId);
-
-        if (opts.phase) {
-          sessions = sessions.filter((h) => h.phase === opts.phase);
-        }
+        const sessions = getClaudeSessions(ticket, opts.phase);
 
         if (sessions.length === 0) {
           console.log("No Claude sessions found for this ticket.");
@@ -103,10 +113,7 @@ export function register(
         let sessionId = sessionIdArg;
 
         if (!sessionId) {
-          let sessions = ticket.phaseHistory.filter((h) => h.sessionId);
-          if (opts.phase) {
-            sessions = sessions.filter((h) => h.phase === opts.phase);
-          }
+          const sessions = getClaudeSessions(ticket, opts.phase);
           const latest = sessions[sessions.length - 1];
           sessionId = latest?.sessionId;
         }
@@ -115,6 +122,16 @@ export function register(
           console.error(
             chalk.red(
               "No session ID found. Provide one explicitly or check the ticket has Claude sessions.",
+            ),
+          );
+          process.exitCode = 1;
+          return;
+        }
+
+        if (!SESSION_ID_PATTERN.test(sessionId)) {
+          console.error(
+            chalk.red(
+              "Invalid session ID format. Expected alphanumeric characters, hyphens, or underscores.",
             ),
           );
           process.exitCode = 1;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -65,6 +65,14 @@ async function printTicketDetail(
   if (ticket.context.pr_url) {
     console.log(`    PR: ${chalk.dim(ticket.context.pr_url)}`);
   }
+
+  const sessionsWithId = ticket.phaseHistory.filter((h) => h.sessionId);
+  if (sessionsWithId.length > 0) {
+    const latest = sessionsWithId[sessionsWithId.length - 1];
+    console.log(
+      `    Session: ${chalk.dim(latest.sessionId)} ${chalk.dim(`(${latest.phase})`)}`,
+    );
+  }
 }
 
 export function register(

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -200,12 +200,19 @@ export function createRunner(config: OrchestratorConfig): Runner {
       log.error(`Phase "${ticket.currentPhase}" failed (${durationMs}ms)`);
     }
 
+    if (result.sessionId) {
+      log.info(
+        `Phase "${ticket.currentPhase}" Claude session: ${result.sessionId}`,
+      );
+    }
+
     const historyEntry = {
       phase: ticket.currentPhase,
       status: (result.success ? "success" : "failure") as "success" | "failure",
       startedAt,
       completedAt,
       output: result.output.slice(0, 4096),
+      sessionId: result.sessionId,
     };
 
     // Merge captured values into context

--- a/src/core/types.test.ts
+++ b/src/core/types.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   AgentConfigSchema,
   OrchestratorConfigSchema,
+  PhaseHistoryEntrySchema,
   PlanFileSchema,
   RawOrchestratorConfigSchema,
   TicketStatusSchema,
@@ -193,6 +194,29 @@ describe("PlanFileSchema", () => {
   it("accepts a string repo for single-repo plans", () => {
     const result = PlanFileSchema.parse(validPlan);
     expect(result.repo).toBe("my-repo");
+  });
+});
+
+describe("PhaseHistoryEntrySchema", () => {
+  it("parses entry without sessionId", () => {
+    const result = PhaseHistoryEntrySchema.parse({
+      phase: "implement",
+      status: "success",
+      startedAt: "2025-01-01T00:00:00Z",
+      completedAt: "2025-01-01T00:05:00Z",
+    });
+    expect(result.sessionId).toBeUndefined();
+  });
+
+  it("parses entry with sessionId", () => {
+    const result = PhaseHistoryEntrySchema.parse({
+      phase: "implement",
+      status: "success",
+      startedAt: "2025-01-01T00:00:00Z",
+      completedAt: "2025-01-01T00:05:00Z",
+      sessionId: "cc807f8c-1234-5678-abcd-ef0123456789",
+    });
+    expect(result.sessionId).toBe("cc807f8c-1234-5678-abcd-ef0123456789");
   });
 });
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -104,6 +104,7 @@ export const PhaseHistoryEntrySchema = z.object({
   startedAt: z.string(),
   completedAt: z.string().nullable(),
   output: z.string().optional(),
+  sessionId: z.string().optional(),
 });
 
 export type PhaseHistoryEntry = z.infer<typeof PhaseHistoryEntrySchema>;

--- a/src/phases/executor.ts
+++ b/src/phases/executor.ts
@@ -18,6 +18,7 @@ export interface PhaseResult {
   captured: Record<string, string>;
   nextPhase: string | null;
   pending?: boolean;
+  sessionId?: string;
 }
 
 export interface PhaseExecutor {
@@ -164,6 +165,7 @@ export function createPhaseExecutor(
       output: agentResult.stdout,
       captured,
       nextPhase,
+      sessionId: agentResult.sessionId,
     };
   }
 


### PR DESCRIPTION
## Summary

- **Session capture**: Switch Claude CLI output format from `text` to `json` to extract `session_id` and `result` from structured output. Non-Claude agents are unaffected.
- **Persistence**: Add `sessionId` field to `PhaseHistoryEntry` schema and propagate through `AgentResult` → `PhaseResult` → runner history entries. Session IDs are logged to console and log file.
- **New CLI commands**: `orchestrator sessions <planId> <ticketId>` lists Claude sessions (with `--phase` and `--json` filters), and `orchestrator resume-session <planId> <ticketId> [sessionId]` resumes a session interactively via `claude --resume`.
- **Status enhancement**: `orchestrator status` now shows the latest session ID for tickets with Claude sessions.

## Test plan

- [x] `parseClaudeJsonOutput` tests: valid JSON with/without session_id, invalid JSON fallback, missing result field
- [x] `buildAgentArgs` test updated for `json` output format
- [x] `PhaseHistoryEntrySchema` tests: parses with and without sessionId
- [x] All 194 existing tests pass
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)