### PR TITLE
LOCK-DAEMON: add PID lockfile for daemon startup

### DIFF
--- a/src/agents/interactive.test.ts
+++ b/src/agents/interactive.test.ts
@@ -8,6 +8,7 @@ const mockConfig: OrchestratorConfig = {
   agents: {
     claude: { command: "claude", defaultArgs: ["--verbose"] },
   },
+  orchestratorHome: "/abs/home",
   stateDir: "/abs/state",
   logDir: "/abs/logs",
   workflowDir: "/abs/workflows",

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -85,8 +85,6 @@ export function register(
         process.off("SIGINT", shutdown);
         process.off("SIGTERM", shutdown);
       }
-
-      console.log(chalk.bold("Daemon stopped"));
       process.exit(process.exitCode ?? 0);
     });
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import type { Command } from "commander";
 import type { LoadConfigOptions } from "../core/config.js";
 import { loadConfig } from "../core/config.js";
-import { createRunner } from "../core/runner.js";
+import { createRunner, DaemonAlreadyRunningError } from "../core/runner.js";
 import { colorStatus } from "./status.js";
 
 export function register(
@@ -69,15 +69,21 @@ export function register(
       process.on("SIGINT", shutdown);
       process.on("SIGTERM", shutdown);
 
-      console.log(chalk.bold("Daemon started"));
-
       const runner = createRunner(config);
       try {
         await runner.startDaemon({ signal: controller.signal });
       } catch (err) {
+        if (err instanceof DaemonAlreadyRunningError) {
+          console.log(chalk.yellow(err.message));
+          process.exitCode = 0;
+          return;
+        }
         const msg = err instanceof Error ? err.message : String(err);
         console.error(chalk.red(`Daemon error: ${msg}`));
         process.exitCode = 1;
+      } finally {
+        process.off("SIGINT", shutdown);
+        process.off("SIGTERM", shutdown);
       }
 
       console.log(chalk.bold("Daemon stopped"));

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -85,7 +85,6 @@ export function register(
         process.off("SIGINT", shutdown);
         process.off("SIGTERM", shutdown);
       }
-      process.exit(process.exitCode ?? 0);
     });
 
   program

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -121,6 +121,7 @@ describe("loadConfig", () => {
 
     const config = await loadConfig({ configPath, packageDir: pkgDir });
     expect(config.defaultAgent).toBe("claude");
+    expect(config.orchestratorHome).toBe(resolveOrchestratorHome());
     expect(config.pollInterval).toBe(10);
     expect(config.maxConcurrency).toBe(3);
   });
@@ -170,6 +171,7 @@ describe("loadConfig", () => {
     const config = await loadConfig({ configPath, packageDir: pkgDir });
 
     // User data dirs default to home
+    expect(config.orchestratorHome).toBe(join(tmpDir, "home"));
     expect(config.stateDir).toBe(join(tmpDir, "home", "state"));
     expect(config.logDir).toBe(join(tmpDir, "home", "logs"));
 
@@ -229,6 +231,7 @@ describe("resolveAgent", () => {
       claude: { command: "claude", defaultArgs: [] },
       codex: { command: "codex", defaultArgs: [] },
     },
+    orchestratorHome: "/tmp/orchestrator",
     stateDir: "/tmp/state",
     logDir: "/tmp/logs",
     workflowDir: "/tmp/workflows",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -95,6 +95,7 @@ export async function loadConfig(
 
   const resolved: OrchestratorConfig = {
     ...rawConfig,
+    orchestratorHome: home,
     // User data dirs default to ~/.orchestrator/<name>
     stateDir: resolveDir(rawConfig.stateDir, join(home, "state")),
     logDir: resolveDir(rawConfig.logDir, join(home, "logs")),

--- a/src/core/runner.test.ts
+++ b/src/core/runner.test.ts
@@ -20,7 +20,6 @@ describe("runner", () => {
   let scriptDir: string;
   let promptDir: string;
   let logDir: string;
-  let lockPath: string;
   let config: OrchestratorConfig;
 
   const minimalYaml = `
@@ -114,7 +113,6 @@ phases:
     scriptDir = join(tmpDir, "scripts");
     promptDir = join(tmpDir, "prompts");
     logDir = join(tmpDir, "logs");
-    lockPath = join(tmpDir, "daemon.pid");
     await mkdir(stateDir, { recursive: true });
     await mkdir(workflowDir, { recursive: true });
     await mkdir(scriptDir, { recursive: true });

--- a/src/core/runner.test.ts
+++ b/src/core/runner.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createRunner, resolveTicketRepo } from "./runner.js";
 import type { OrchestratorConfig, PlanFile, TicketState } from "./types.js";
 
@@ -20,6 +20,7 @@ describe("runner", () => {
   let scriptDir: string;
   let promptDir: string;
   let logDir: string;
+  let lockPath: string;
   let config: OrchestratorConfig;
 
   const minimalYaml = `
@@ -113,7 +114,7 @@ phases:
     scriptDir = join(tmpDir, "scripts");
     promptDir = join(tmpDir, "prompts");
     logDir = join(tmpDir, "logs");
-
+    lockPath = join(tmpDir, "daemon.pid");
     await mkdir(stateDir, { recursive: true });
     await mkdir(workflowDir, { recursive: true });
     await mkdir(scriptDir, { recursive: true });
@@ -127,6 +128,7 @@ phases:
       agents: {
         claude: { command: "claude", defaultArgs: [] },
       },
+      orchestratorHome: tmpDir,
       stateDir,
       logDir,
       workflowDir,
@@ -399,6 +401,92 @@ phases:
 
       // Should have stopped within reasonable time (not running indefinitely)
       expect(elapsed).toBeLessThan(5000);
+    });
+
+    it("creates a daemon lockfile on startup and removes it on shutdown", async () => {
+      const runner = createRunner({ ...config, pollInterval: 0.1 });
+      const lockPath = join(config.orchestratorHome, "daemon.pid");
+      const controller = new AbortController();
+      const daemonPromise = runner.startDaemon({ signal: controller.signal });
+
+      await vi.waitFor(async () => {
+        const pid = (await readFile(lockPath, "utf-8")).trim();
+        expect(pid).toBe(String(process.pid));
+      });
+
+      controller.abort();
+      await daemonPromise;
+      await expect(access(lockPath, constants.F_OK)).rejects.toThrow();
+    });
+
+    it("prevents starting a second daemon when a live daemon lock exists", async () => {
+      const lockPath = join(config.orchestratorHome, "daemon.pid");
+      await writeFile(lockPath, "4242\n");
+
+      const runner = createRunner(config, {
+        processInspector: {
+          isRunning: async (pid) => pid === 4242,
+          describe: async (pid) =>
+            pid === 4242 ? "node /usr/local/bin/orchestrator daemon" : null,
+        },
+      });
+
+      await expect(runner.startDaemon()).rejects.toThrow(
+        "Another orchestrator daemon is already running",
+      );
+      expect((await readFile(lockPath, "utf-8")).trim()).toBe("4242");
+    });
+
+    it("replaces a stale daemon lock when the recorded pid is not running", async () => {
+      const lockPath = join(config.orchestratorHome, "daemon.pid");
+      await writeFile(lockPath, "4242\n");
+
+      const runner = createRunner(
+        { ...config, pollInterval: 0.1 },
+        {
+          processInspector: {
+            isRunning: async () => false,
+            describe: async () => null,
+          },
+        },
+      );
+      const controller = new AbortController();
+      const daemonPromise = runner.startDaemon({ signal: controller.signal });
+
+      await vi.waitFor(async () => {
+        const pid = (await readFile(lockPath, "utf-8")).trim();
+        expect(pid).toBe(String(process.pid));
+      });
+
+      controller.abort();
+      await daemonPromise;
+      await expect(access(lockPath, constants.F_OK)).rejects.toThrow();
+    });
+
+    it("replaces a lock when the pid is running but is not an orchestrator daemon", async () => {
+      const lockPath = join(config.orchestratorHome, "daemon.pid");
+      await writeFile(lockPath, "4242\n");
+
+      const runner = createRunner(
+        { ...config, pollInterval: 0.1 },
+        {
+          processInspector: {
+            isRunning: async () => true,
+            describe: async () => "bash -lc sleep 100",
+          },
+        },
+      );
+      const controller = new AbortController();
+      const daemonPromise = runner.startDaemon({ signal: controller.signal });
+
+      await vi.waitFor(async () => {
+        const pid = (await readFile(lockPath, "utf-8")).trim();
+        expect(pid).toBe(String(process.pid));
+      });
+
+      controller.abort();
+      await daemonPromise;
+      await expect(access(lockPath, constants.F_OK)).rejects.toThrow();
     });
   });
 

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -37,12 +37,10 @@ const defaultProcessInspector: ProcessInspector = {
       process.kill(pid, 0);
       return true;
     } catch (error) {
-      return !(
-        error &&
-        typeof error === "object" &&
-        "code" in error &&
-        error.code === "ESRCH"
-      );
+      if (error && typeof error === "object" && "code" in error) {
+        return error.code !== "ESRCH";
+      }
+      return true;
     }
   },
 
@@ -102,16 +100,15 @@ async function acquireDaemonLock(
     }
 
     const existingPid = await readLockPid(lockPath);
-    const command =
-      existingPid !== null && (await processInspector.isRunning(existingPid))
-        ? ((await processInspector.describe(existingPid))?.toLowerCase() ?? "")
-        : "";
     if (
       existingPid !== null &&
-      command.includes("orchestrator") &&
-      command.includes("daemon")
+      (await processInspector.isRunning(existingPid))
     ) {
-      throw new DaemonAlreadyRunningError(existingPid);
+      const command =
+        (await processInspector.describe(existingPid))?.toLowerCase() ?? "";
+      if (command.includes("orchestrator") && command.includes("daemon")) {
+        throw new DaemonAlreadyRunningError(existingPid);
+      }
     }
 
     await rm(lockPath, { force: true });

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -43,6 +43,8 @@ const defaultProcessInspector: ProcessInspector = {
         return error.code !== "ESRCH";
       }
 
+      // Unknown errors are treated as "still running" so we do not
+      // accidentally steal a live daemon's lock.
       return true;
     }
   },

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -38,8 +38,11 @@ const defaultProcessInspector: ProcessInspector = {
       return true;
     } catch (error) {
       if (error && typeof error === "object" && "code" in error) {
+        // ESRCH means the process no longer exists. Other errors such as
+        // EPERM still indicate a live process that we cannot signal.
         return error.code !== "ESRCH";
       }
+
       return true;
     }
   },

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -1,3 +1,7 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, open, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import type { PhaseResult } from "../phases/executor.js";
 import { createPhaseExecutor } from "../phases/executor.js";
 import { createLogger } from "../utils/logger.js";
@@ -5,6 +9,120 @@ import { createStateManager } from "./state.js";
 import { createTemplateRenderer } from "./template.js";
 import type { OrchestratorConfig, TicketState } from "./types.js";
 import { createWorkflowLoader } from "./workflow.js";
+
+const execFile = promisify(execFileCallback);
+const DAEMON_LOCK_FILE = "daemon.pid";
+
+export class DaemonAlreadyRunningError extends Error {
+  constructor(readonly pid: number) {
+    super(
+      `Another orchestrator daemon is already running (PID ${pid}). Stop it before starting a new daemon.`,
+    );
+    this.name = "DaemonAlreadyRunningError";
+  }
+}
+
+export interface ProcessInspector {
+  isRunning(pid: number): Promise<boolean>;
+  describe(pid: number): Promise<string | null>;
+}
+
+export interface RunnerDependencies {
+  processInspector?: ProcessInspector;
+}
+
+const defaultProcessInspector: ProcessInspector = {
+  async isRunning(pid) {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      return !(
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        error.code === "ESRCH"
+      );
+    }
+  },
+
+  async describe(pid) {
+    try {
+      const { stdout } = await execFile("ps", [
+        "-p",
+        String(pid),
+        "-o",
+        "command=",
+      ]);
+      const command = stdout.trim();
+      return command.length > 0 ? command : null;
+    } catch {
+      return null;
+    }
+  },
+};
+
+async function readLockPid(lockPath: string): Promise<number | null> {
+  try {
+    const trimmed = (await readFile(lockPath, "utf-8")).trim();
+    if (!/^\d+$/.test(trimmed)) {
+      return null;
+    }
+
+    const pid = Number.parseInt(trimmed, 10);
+    return pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function acquireDaemonLock(
+  config: OrchestratorConfig,
+  processInspector: ProcessInspector,
+): Promise<string> {
+  const lockPath = join(config.orchestratorHome, DAEMON_LOCK_FILE);
+  await mkdir(config.orchestratorHome, { recursive: true });
+
+  while (true) {
+    try {
+      const handle = await open(lockPath, "wx");
+      try {
+        await handle.writeFile(`${process.pid}\n`);
+      } finally {
+        await handle.close();
+      }
+      return lockPath;
+    } catch (error) {
+      if (!error || typeof error !== "object" || !("code" in error)) {
+        throw error;
+      }
+      if (error.code !== "EEXIST") {
+        throw error;
+      }
+    }
+
+    const existingPid = await readLockPid(lockPath);
+    const command =
+      existingPid !== null && (await processInspector.isRunning(existingPid))
+        ? ((await processInspector.describe(existingPid))?.toLowerCase() ?? "")
+        : "";
+    if (
+      existingPid !== null &&
+      command.includes("orchestrator") &&
+      command.includes("daemon")
+    ) {
+      throw new DaemonAlreadyRunningError(existingPid);
+    }
+
+    await rm(lockPath, { force: true });
+  }
+}
+
+async function releaseDaemonLock(lockPath: string): Promise<void> {
+  if ((await readLockPid(lockPath)) === process.pid) {
+    await rm(lockPath, { force: true });
+  }
+}
 
 export interface Runner {
   runSingleTicket(planId: string, ticketId: string): Promise<TicketState>;
@@ -44,12 +162,17 @@ export function resolveTicketRepo(
   return { ...ticket, repo: resolved };
 }
 
-export function createRunner(config: OrchestratorConfig): Runner {
+export function createRunner(
+  config: OrchestratorConfig,
+  dependencies: RunnerDependencies = {},
+): Runner {
   const stateManager = createStateManager(config.stateDir);
   const workflowLoader = createWorkflowLoader(config.workflowSearchPath);
   const templateRenderer = createTemplateRenderer(config.promptSearchPath);
   const logger = createLogger(config.logDir);
   const phaseExecutor = createPhaseExecutor(config, templateRenderer, logger);
+  const processInspector =
+    dependencies.processInspector ?? defaultProcessInspector;
 
   interface InFlightEntry {
     planId: string;
@@ -478,14 +601,19 @@ export function createRunner(config: OrchestratorConfig): Runner {
     },
 
     async startDaemon(options) {
+      const lockPath = await acquireDaemonLock(config, processInspector);
+
       logger.info("Daemon started");
 
-      while (!options?.signal?.aborted) {
-        await this.tick();
-        await sleep(config.pollInterval * 1000, options?.signal);
+      try {
+        while (!options?.signal?.aborted) {
+          await this.tick();
+          await sleep(config.pollInterval * 1000, options?.signal);
+        }
+      } finally {
+        await releaseDaemonLock(lockPath);
+        logger.info("Daemon stopped");
       }
-
-      logger.info("Daemon stopped");
     },
   };
 }

--- a/src/core/types.test.ts
+++ b/src/core/types.test.ts
@@ -81,6 +81,7 @@ describe("OrchestratorConfigSchema", () => {
     agents: {
       claude: { command: "claude", defaultArgs: [] },
     },
+    orchestratorHome: ".orchestrator",
     stateDir: ".state",
     logDir: ".logs",
     workflowDir: "workflows",
@@ -120,6 +121,11 @@ describe("OrchestratorConfigSchema", () => {
   it("rejects missing skillsDir", () => {
     const { skillsDir, ...withoutSkills } = validConfig;
     expect(() => OrchestratorConfigSchema.parse(withoutSkills)).toThrow();
+  });
+
+  it("rejects missing orchestratorHome", () => {
+    const { orchestratorHome, ...withoutHome } = validConfig;
+    expect(() => OrchestratorConfigSchema.parse(withoutHome)).toThrow();
   });
 });
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -39,6 +39,7 @@ export type RawOrchestratorConfig = z.infer<typeof RawOrchestratorConfigSchema>;
 export const OrchestratorConfigSchema = z.object({
   defaultAgent: z.string(),
   agents: z.record(z.string(), AgentConfigSchema),
+  orchestratorHome: z.string(),
   stateDir: z.string(),
   logDir: z.string(),
   workflowDir: z.string(),

--- a/src/phases/executor.test.ts
+++ b/src/phases/executor.test.ts
@@ -62,6 +62,7 @@ describe("executor", () => {
       agents: {
         claude: { command: "claude", defaultArgs: [] },
       },
+      orchestratorHome: tmpDir,
       stateDir: join(tmpDir, "state"),
       logDir: join(tmpDir, "logs"),
       workflowDir: join(tmpDir, "workflows"),


### PR DESCRIPTION
## Summary
- add a `daemon.pid` lock in the orchestrator home so only one daemon instance can run at a time
- verify an existing PID is both live and looks like an orchestrator daemon before refusing startup
- recover from stale or mismatched lockfiles and remove the lock on clean shutdown
- cover lock acquisition, live-lock rejection, and stale-lock recovery in runner tests

## Validation
- `pnpm run lint:fix`
- `pnpm run typecheck`
- `pnpm run test`

## Why
This prevents accidentally starting multiple daemon loops against the same orchestrator state while still recovering safely from stale PID files.