### PR TITLE
AO-LIMITS-1: Increase agent timeout, make configurable, remove --max-turns

### DIFF
--- a/src/agents/invoke.test.ts
+++ b/src/agents/invoke.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import * as shell from "../utils/shell.js";
 import {
   buildAgentArgs,
   invokeAgent,
@@ -31,16 +32,6 @@ describe("buildAgentArgs", () => {
     expect(result.args).toContain("--allowedTools");
     expect(result.args).toContain("Read");
     expect(result.args).toContain("Write");
-  });
-
-  it("includes maxTurns for claude", () => {
-    const result = buildAgentArgs(
-      { command: "claude", defaultArgs: [] },
-      { prompt: "do stuff", maxTurns: 5 },
-    );
-
-    expect(result.args).toContain("--max-turns");
-    expect(result.args).toContain("5");
   });
 
   it("builds args for codex agent", () => {
@@ -132,5 +123,47 @@ describe("invokeAgent", () => {
     expect(result.success).toBe(true);
     expect(chunks.length).toBeGreaterThan(0);
     expect(chunks.join("").trim()).toBe("streamed output");
+  });
+
+  it("passes custom timeoutMs to execCommandStreaming", async () => {
+    const spy = vi.spyOn(shell, "execCommandStreaming").mockResolvedValue({
+      stdout: "ok",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    await invokeAgent(
+      { command: "echo", defaultArgs: [] },
+      { prompt: "hello", timeoutMs: 120000 },
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      "echo",
+      ["hello"],
+      expect.objectContaining({ timeoutMs: 120000 }),
+    );
+
+    spy.mockRestore();
+  });
+
+  it("uses DEFAULT_TIMEOUT_MS when timeoutMs is not provided", async () => {
+    const spy = vi.spyOn(shell, "execCommandStreaming").mockResolvedValue({
+      stdout: "ok",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    await invokeAgent(
+      { command: "echo", defaultArgs: [] },
+      { prompt: "hello" },
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      "echo",
+      ["hello"],
+      expect.objectContaining({ timeoutMs: 60 * 60 * 1000 }),
+    );
+
+    spy.mockRestore();
   });
 });

--- a/src/agents/invoke.test.ts
+++ b/src/agents/invoke.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as shell from "../utils/shell.js";
 import {
   buildAgentArgs,
@@ -125,45 +125,45 @@ describe("invokeAgent", () => {
     expect(chunks.join("").trim()).toBe("streamed output");
   });
 
-  it("passes custom timeoutMs to execCommandStreaming", async () => {
-    const spy = vi.spyOn(shell, "execCommandStreaming").mockResolvedValue({
-      stdout: "ok",
-      stderr: "",
-      exitCode: 0,
+  describe("timeout handling", () => {
+    let spy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      spy = vi.spyOn(shell, "execCommandStreaming").mockResolvedValue({
+        stdout: "ok",
+        stderr: "",
+        exitCode: 0,
+      });
     });
 
-    await invokeAgent(
-      { command: "echo", defaultArgs: [] },
-      { prompt: "hello", timeoutMs: 120000 },
-    );
-
-    expect(spy).toHaveBeenCalledWith(
-      "echo",
-      ["hello"],
-      expect.objectContaining({ timeoutMs: 120000 }),
-    );
-
-    spy.mockRestore();
-  });
-
-  it("uses DEFAULT_TIMEOUT_MS when timeoutMs is not provided", async () => {
-    const spy = vi.spyOn(shell, "execCommandStreaming").mockResolvedValue({
-      stdout: "ok",
-      stderr: "",
-      exitCode: 0,
+    afterEach(() => {
+      spy.mockRestore();
     });
 
-    await invokeAgent(
-      { command: "echo", defaultArgs: [] },
-      { prompt: "hello" },
-    );
+    it("passes custom timeoutMs to execCommandStreaming", async () => {
+      await invokeAgent(
+        { command: "echo", defaultArgs: [] },
+        { prompt: "hello", timeoutMs: 120000 },
+      );
 
-    expect(spy).toHaveBeenCalledWith(
-      "echo",
-      ["hello"],
-      expect.objectContaining({ timeoutMs: 60 * 60 * 1000 }),
-    );
+      expect(spy).toHaveBeenCalledWith(
+        "echo",
+        ["hello"],
+        expect.objectContaining({ timeoutMs: 120000 }),
+      );
+    });
 
-    spy.mockRestore();
+    it("uses DEFAULT_TIMEOUT_MS when timeoutMs is not provided", async () => {
+      await invokeAgent(
+        { command: "echo", defaultArgs: [] },
+        { prompt: "hello" },
+      );
+
+      expect(spy).toHaveBeenCalledWith(
+        "echo",
+        ["hello"],
+        expect.objectContaining({ timeoutMs: 60 * 60 * 1000 }),
+      );
+    });
   });
 });

--- a/src/agents/invoke.ts
+++ b/src/agents/invoke.ts
@@ -5,7 +5,7 @@ export interface AgentInvocation {
   prompt: string;
   cwd?: string;
   allowedTools?: string[];
-  maxTurns?: number;
+  timeoutMs?: number;
 }
 
 export interface AgentResult {
@@ -20,22 +20,19 @@ export interface AgentCallbacks {
   onOutput?: (chunk: string) => void;
 }
 
-const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 
 export function buildAgentArgs(
   agentConfig: AgentConfig,
   invocation: AgentInvocation,
 ): { command: string; args: string[] } {
   const { command, defaultArgs } = agentConfig;
-  const { prompt, allowedTools, maxTurns } = invocation;
+  const { prompt, allowedTools } = invocation;
 
   if (command === "claude") {
     const args = ["-p", prompt, "--output-format", "json", ...defaultArgs];
     if (allowedTools?.length) {
       args.push("--allowedTools", ...allowedTools);
-    }
-    if (maxTurns !== undefined) {
-      args.push("--max-turns", String(maxTurns));
     }
     return { command, args };
   }
@@ -75,7 +72,7 @@ export async function invokeAgent(
 
   const result = await execCommandStreaming(command, args, {
     cwd: invocation.cwd || undefined,
-    timeoutMs: DEFAULT_TIMEOUT_MS,
+    timeoutMs: invocation.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     onStdout: callbacks?.onOutput,
     signal: options?.signal,
   });

--- a/src/phases/executor.ts
+++ b/src/phases/executor.ts
@@ -149,7 +149,9 @@ export function createPhaseExecutor(
         prompt,
         cwd: resolveCwd(ticket),
         allowedTools: phase.allowedTools,
-        maxTurns: phase.maxTurns,
+        timeoutMs: phase.timeoutSeconds
+          ? phase.timeoutSeconds * 1000
+          : undefined,
       },
       {
         onOutput: (chunk) => log.trace(chunk),


### PR DESCRIPTION
## Summary

- **Increased default agent timeout** from 30 minutes to 60 minutes to prevent complex implementation tickets from being killed mid-work
- **Made agent timeout configurable per-phase** via the existing `timeoutSeconds` field in workflow YAML — the agent phase executor now passes this through to `invokeAgent`, matching what the script phase executor already does
- **Removed `--max-turns` flag** from Claude agent args — hitting the turn limit caused Claude to exit with "Error: Reached max turns" and leave incomplete results; agents now rely solely on the timeout to bound execution

## Changes

- `src/agents/invoke.ts` — bumped `DEFAULT_TIMEOUT_MS` to 60 min, added optional `timeoutMs` to `AgentInvocation`, removed `--max-turns` from `buildAgentArgs` for Claude
- `src/phases/executor.ts` — agent phase executor now converts `phase.timeoutSeconds` to ms and passes it to `invokeAgent`
- `src/agents/invoke.test.ts` — removed `--max-turns` test, added tests for custom and default timeout passthrough

## Test plan

- [x] `pnpm run lint:fix` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes (189 tests)
- [ ] Verify in a real workflow that `timeoutSeconds` on an agent phase overrides the default timeout
- [ ] Verify Claude agents no longer receive `--max-turns` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)