### PR TITLE
ORCH-001: handle regular PR comments in await_review

### DIFF
--- a/scripts/check-pr-review.sh
+++ b/scripts/check-pr-review.sh
@@ -201,19 +201,17 @@ ci_failed=$(gh pr checks "$PR_NUMBER" --json bucket \
   --jq '[.[] | select(.bucket == "fail")] | length' 2>/dev/null) || ci_failed="0"
 
 # CHANGES_REQUESTED is actionable
-if [ "$review_decision" = "CHANGES_REQUESTED" ] || {
-  [ "$unresolved_comments" != "0" ] && [ "$unresolved_comments" != "" ]
-}; then
+if [ "$review_decision" = "CHANGES_REQUESTED" ] || [ "${unresolved_comments:-0}" -gt 0 ]; then
   echo "changes_requested"
   exit 0
 fi
 
-if [ "$actionable_pr_comments" != "0" ] && [ "$actionable_pr_comments" != "" ]; then
+if [ "${actionable_pr_comments:-0}" -gt 0 ]; then
   echo "commented"
   exit 0
 fi
 
-if [ "$ci_failed" != "0" ] && [ "$ci_failed" != "" ]; then
+if [ "${ci_failed:-0}" -gt 0 ]; then
   echo "ci_failed"
   exit 0
 fi

--- a/scripts/check-pr-review.sh
+++ b/scripts/check-pr-review.sh
@@ -11,14 +11,16 @@ pr_state=$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null) || {
   echo "Error fetching PR state" >&2
   exit 2
 }
-if [ "$pr_state" = "MERGED" ]; then
-  echo "merged"
-  exit 0
-fi
-if [ "$pr_state" = "CLOSED" ]; then
-  echo "closed"
-  exit 2
-fi
+case "$pr_state" in
+  MERGED)
+    echo "merged"
+    exit 0
+    ;;
+  CLOSED)
+    echo "closed"
+    exit 2
+    ;;
+esac
 
 # Resolve owner/repo for GraphQL queries
 REPO_NWO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) || {
@@ -34,14 +36,54 @@ review_decision=$(gh pr view "$PR_NUMBER" --json reviewDecision --jq '.reviewDec
   exit 2
 }
 
-# Check for unresolved review threads via GraphQL
-# (uses temp file to avoid bash ! interpretation issues in query string)
+# Check for unresolved review threads and actionable PR conversation comments.
+# A regular PR comment is actionable when it comes from someone other than the
+# PR author and is newer than the PR author's last PR activity. If the author
+# has not commented, reviewed, or pushed follow-up commits yet, the baseline is
+# the PR creation time.
 _gql_tmp=$(mktemp)
-trap 'rm -f "$_gql_tmp"' EXIT
+_gql_response_tmp=$(mktemp)
+trap 'rm -f "$_gql_tmp" "$_gql_response_tmp"' EXIT
 cat > "$_gql_tmp" << 'GRAPHQL'
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
+      createdAt
+      author {
+        login
+      }
+      comments(first: 100) {
+        nodes {
+          author {
+            login
+          }
+          createdAt
+          isMinimized
+        }
+      }
+      reviews(first: 100) {
+        nodes {
+          author {
+            login
+          }
+          submittedAt
+        }
+      }
+      commits(last: 100) {
+        nodes {
+          commit {
+            authoredDate
+            committedDate
+            authors(first: 10) {
+              nodes {
+                user {
+                  login
+                }
+              }
+            }
+          }
+        }
+      }
       reviewThreads(first: 100) {
         nodes {
           isResolved
@@ -51,36 +93,131 @@ query($owner: String!, $repo: String!, $number: Int!) {
   }
 }
 GRAPHQL
-unresolved_comments=$(gh api graphql \
+gh api graphql \
   -F owner="$OWNER" \
   -F repo="$REPO" \
   -F number="$PR_NUMBER" \
   -F "query=@$_gql_tmp" \
-  --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length' 2>/dev/null) || unresolved_comments="0"
+  > "$_gql_response_tmp" 2>/dev/null || {
+  echo "Error fetching PR review details" >&2
+  exit 2
+}
+
+analysis_output=$(node - "$_gql_response_tmp" <<'NODE'
+const fs = require("node:fs");
+
+const responsePath = process.argv[2];
+const response = JSON.parse(fs.readFileSync(responsePath, "utf8"));
+const pr = response.data?.repository?.pullRequest;
+
+if (!pr) {
+  console.error("Missing pull request data");
+  process.exit(1);
+}
+
+const parseDate = (value) => {
+  if (!value) {
+    return Number.NaN;
+  }
+  return Date.parse(value);
+};
+
+const comments = pr.comments?.nodes ?? [];
+const reviews = pr.reviews?.nodes ?? [];
+const commits = pr.commits?.nodes ?? [];
+const prAuthor = pr.author?.login ?? "";
+const baselineCandidates = [parseDate(pr.createdAt)];
+
+for (const comment of comments) {
+  if ((comment?.author?.login ?? "") === prAuthor) {
+    baselineCandidates.push(parseDate(comment.createdAt));
+  }
+}
+
+for (const review of reviews) {
+  if ((review?.author?.login ?? "") === prAuthor) {
+    baselineCandidates.push(parseDate(review.submittedAt));
+  }
+}
+
+for (const commitNode of commits) {
+  const commit = commitNode?.commit;
+  const authoredByPrAuthor = (commit?.authors?.nodes ?? []).some(
+    (authorNode) => authorNode?.user?.login === prAuthor,
+  );
+  if (!authoredByPrAuthor) {
+    continue;
+  }
+
+  baselineCandidates.push(parseDate(commit.authoredDate));
+  baselineCandidates.push(parseDate(commit.committedDate));
+}
+
+const baselineTimestamp = baselineCandidates
+  .filter((timestamp) => Number.isFinite(timestamp))
+  .reduce((latest, timestamp) => Math.max(latest, timestamp), 0);
+
+const actionablePrComments = comments.some((comment) => {
+  const authorLogin = comment?.author?.login ?? "";
+  if (!authorLogin || authorLogin === prAuthor) {
+    return false;
+  }
+  if (authorLogin.endsWith("[bot]")) {
+    return false;
+  }
+  if (comment?.isMinimized) {
+    return false;
+  }
+
+  const createdAt = parseDate(comment.createdAt);
+  return Number.isFinite(createdAt) && createdAt > baselineTimestamp;
+});
+
+const unresolvedComments = (pr.reviewThreads?.nodes ?? []).filter(
+  (thread) => thread?.isResolved === false,
+).length;
+
+process.stdout.write(`UNRESOLVED_COMMENTS=${unresolvedComments}\n`);
+process.stdout.write(
+  `ACTIONABLE_PR_COMMENTS=${actionablePrComments ? "1" : "0"}\n`,
+);
+NODE
+) || {
+  echo "Error analyzing PR review details" >&2
+  exit 2
+}
+
+unresolved_comments="0"
+actionable_pr_comments="0"
+while IFS='=' read -r key value; do
+  case "$key" in
+    UNRESOLVED_COMMENTS) unresolved_comments="$value" ;;
+    ACTIONABLE_PR_COMMENTS) actionable_pr_comments="$value" ;;
+  esac
+done <<< "$analysis_output"
 
 # Check CI status
 ci_failed=$(gh pr checks "$PR_NUMBER" --json bucket \
   --jq '[.[] | select(.bucket == "fail")] | length' 2>/dev/null) || ci_failed="0"
 
-# CHANGES_REQUESTED is actionable — exit 2 so the poll phase treats it as failure
-if [ "$review_decision" = "CHANGES_REQUESTED" ]; then
+# CHANGES_REQUESTED is actionable
+if [ "$review_decision" = "CHANGES_REQUESTED" ] || {
+  [ "$unresolved_comments" != "0" ] && [ "$unresolved_comments" != "" ]
+}; then
   echo "changes_requested"
-  exit 2
+  exit 0
 fi
 
-# Unresolved review comments take priority over approval
-if [ "$unresolved_comments" != "0" ] && [ "$unresolved_comments" != "" ]; then
-  echo "changes_requested"
-  exit 2
+if [ "$actionable_pr_comments" != "0" ] && [ "$actionable_pr_comments" != "" ]; then
+  echo "commented"
+  exit 0
 fi
 
-# CI failures are actionable
 if [ "$ci_failed" != "0" ] && [ "$ci_failed" != "" ]; then
   echo "ci_failed"
-  exit 2
+  exit 0
 fi
 
-# APPROVED and no unresolved comments — ready to merge
 if [ "$review_decision" = "APPROVED" ]; then
   echo "approved"
   exit 0

--- a/scripts/route-review.sh
+++ b/scripts/route-review.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+review_state="$(printf '%s' "${1:-}" | tr -d '[:space:]')"
+
+case "$review_state" in
+  approved|merged)
+    exit 0
+    ;;
+  changes_requested|commented|ci_failed)
+    exit 1
+    ;;
+  *)
+    echo "Unknown review state: $review_state" >&2
+    exit 2
+    ;;
+esac

--- a/src/core/check-pr-review.test.ts
+++ b/src/core/check-pr-review.test.ts
@@ -1,0 +1,251 @@
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+function makeGraphqlResponse(
+  overrides: {
+    comments?: Array<{
+      author?: string;
+      createdAt: string;
+      isMinimized?: boolean;
+    }>;
+    commits?: Array<{
+      author?: string;
+      authoredDate?: string;
+      committedDate?: string;
+    }>;
+    createdAt?: string;
+    prAuthor?: string;
+    reviewThreads?: Array<{ isResolved: boolean }>;
+    reviews?: Array<{
+      author?: string;
+      submittedAt?: string;
+    }>;
+  } = {},
+) {
+  const prAuthor = overrides.prAuthor ?? "sam";
+
+  return {
+    data: {
+      repository: {
+        pullRequest: {
+          createdAt: overrides.createdAt ?? "2026-03-01T12:00:00Z",
+          author: { login: prAuthor },
+          comments: {
+            nodes: (overrides.comments ?? []).map((comment) => ({
+              author: comment.author ? { login: comment.author } : null,
+              createdAt: comment.createdAt,
+              isMinimized: comment.isMinimized ?? false,
+            })),
+          },
+          reviews: {
+            nodes: (overrides.reviews ?? []).map((review) => ({
+              author: review.author ? { login: review.author } : null,
+              submittedAt: review.submittedAt ?? null,
+            })),
+          },
+          commits: {
+            nodes: (overrides.commits ?? []).map((commit) => ({
+              commit: {
+                authoredDate: commit.authoredDate ?? null,
+                committedDate: commit.committedDate ?? null,
+                authors: {
+                  nodes: commit.author
+                    ? [{ user: { login: commit.author } }]
+                    : [],
+                },
+              },
+            })),
+          },
+          reviewThreads: {
+            nodes: overrides.reviewThreads ?? [],
+          },
+        },
+      },
+    },
+  };
+}
+
+async function runScript(
+  scriptPath: string,
+  args: string[],
+  options: {
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): Promise<{ code: number | null; stderr: string; stdout: string }> {
+  return await new Promise((resolveResult, reject) => {
+    const child = spawn(scriptPath, args, {
+      env: { ...process.env, ...options.env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolveResult({ code, stderr, stdout });
+    });
+  });
+}
+
+describe("check-pr-review.sh", () => {
+  let tmpDir: string;
+  let binDir: string;
+  let repoDir: string;
+  let graphqlResponsePath: string;
+  let scriptPath: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "check-pr-review-test-"));
+    binDir = join(tmpDir, "bin");
+    repoDir = join(tmpDir, "repo");
+    graphqlResponsePath = join(tmpDir, "graphql-response.json");
+    await mkdir(binDir, { recursive: true });
+    await mkdir(repoDir, { recursive: true });
+
+    await writeFile(
+      join(binDir, "gh"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  if [ "$4" = "--json" ] && [ "$5" = "state" ]; then
+    printf '%s\\n' "\${GH_PR_STATE:-OPEN}"
+    exit 0
+  fi
+  if [ "$4" = "--json" ] && [ "$5" = "reviewDecision" ]; then
+    printf '%s\\n' "\${GH_REVIEW_DECISION:-REVIEW_REQUIRED}"
+    exit 0
+  fi
+fi
+
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  printf '%s\\n' "\${GH_REPO_NWO:-test/repo}"
+  exit 0
+fi
+
+if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
+  cat "$GH_GRAPHQL_RESPONSE_FILE"
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
+  printf '%s\\n' "\${GH_CI_FAILED:-0}"
+  exit 0
+fi
+
+echo "Unexpected gh invocation: $*" >&2
+exit 1
+`,
+      { mode: 0o755 },
+    );
+    scriptPath = resolve(
+      dirname(new URL(import.meta.url).pathname),
+      "../../scripts/check-pr-review.sh",
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function invokeCheckPrReview(
+    response: ReturnType<typeof makeGraphqlResponse>,
+    env: NodeJS.ProcessEnv = {},
+  ) {
+    await writeFile(graphqlResponsePath, JSON.stringify(response));
+
+    return await runScript(scriptPath, [repoDir, "123"], {
+      env: {
+        GH_GRAPHQL_RESPONSE_FILE: graphqlResponsePath,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        ...env,
+      },
+    });
+  }
+
+  it("treats a new non-author PR conversation comment as actionable", async () => {
+    const result = await invokeCheckPrReview(
+      makeGraphqlResponse({
+        comments: [
+          {
+            author: "maintainer",
+            createdAt: "2026-03-01T13:00:00Z",
+          },
+        ],
+      }),
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim()).toBe("commented");
+  });
+
+  it("keeps waiting when the PR author already responded after a comment", async () => {
+    const result = await invokeCheckPrReview(
+      makeGraphqlResponse({
+        comments: [
+          {
+            author: "maintainer",
+            createdAt: "2026-03-01T13:00:00Z",
+          },
+          {
+            author: "sam",
+            createdAt: "2026-03-01T14:00:00Z",
+          },
+        ],
+      }),
+    );
+
+    expect(result.code).toBe(1);
+    expect(result.stdout.trim()).toBe("");
+  });
+
+  it("treats PR-author follow-up commits as a response baseline", async () => {
+    const result = await invokeCheckPrReview(
+      makeGraphqlResponse({
+        comments: [
+          {
+            author: "maintainer",
+            createdAt: "2026-03-01T13:00:00Z",
+          },
+        ],
+        commits: [
+          {
+            author: "sam",
+            committedDate: "2026-03-01T14:00:00Z",
+          },
+        ],
+      }),
+    );
+
+    expect(result.code).toBe(1);
+    expect(result.stdout.trim()).toBe("");
+  });
+
+  it("preserves changes requested behavior", async () => {
+    const result = await invokeCheckPrReview(makeGraphqlResponse(), {
+      GH_REVIEW_DECISION: "CHANGES_REQUESTED",
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim()).toBe("changes_requested");
+  });
+
+  it("preserves CI failure behavior", async () => {
+    const result = await invokeCheckPrReview(makeGraphqlResponse(), {
+      GH_CI_FAILED: "2",
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim()).toBe("ci_failed");
+  });
+});

--- a/src/core/runner.test.ts
+++ b/src/core/runner.test.ts
@@ -960,6 +960,17 @@ phases:
     expect(content.startsWith("#!/usr/bin/env bash")).toBe(true);
   });
 
+  it("route-review.sh is executable with correct shebang", async () => {
+    const projectRoot = resolve(
+      dirname(new URL(import.meta.url).pathname),
+      "../..",
+    );
+    const scriptPath = join(projectRoot, "scripts/route-review.sh");
+    await access(scriptPath, constants.X_OK);
+    const content = await readFile(scriptPath, "utf-8");
+    expect(content.startsWith("#!/usr/bin/env bash")).toBe(true);
+  });
+
   describe("closed PR routing", () => {
     const closedPrWorkflowYaml = `
 name: closed-pr-workflow
@@ -1039,6 +1050,110 @@ phases:
 
       expect(result.status).toBe("needs_attention");
       expect(result.currentPhase).toBe("handle_review");
+    });
+  });
+
+  describe("review state routing", () => {
+    const reviewRoutingWorkflowYaml = `
+name: review-routing-workflow
+description: "Workflow with explicit review state routing"
+phases:
+  - id: await_review
+    type: poll
+    command: check-review.sh
+    intervalSeconds: 1
+    timeoutSeconds: 86400
+    capture:
+      review_state: stdout
+    onSuccess: route_review
+    onFailure: route_review_failure
+  - id: route_review
+    type: script
+    command: route-review.sh
+    args:
+      - "{{ context.review_state }}"
+    onSuccess: await_merge
+    onFailure: handle_review
+  - id: route_review_failure
+    type: script
+    command: check-pr-closed.sh
+    args:
+      - "{{ repo }}"
+      - "{{ context.pr_number }}"
+    onSuccess: pr_closed
+    onFailure: escalate
+  - id: await_merge
+    type: terminal
+  - id: handle_review
+    type: terminal
+    notify: true
+  - id: pr_closed
+    type: terminal
+    notify: true
+  - id: escalate
+    type: terminal
+    notify: true
+`;
+
+    async function setupReviewRoutingTest(reviewState: string) {
+      await writeFile(
+        join(scriptDir, "check-review.sh"),
+        `#!/usr/bin/env bash\necho "${reviewState}"\nexit 0`,
+        { mode: 0o755 },
+      );
+      await writeFile(
+        join(scriptDir, "route-review.sh"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+review_state="$(printf '%s' "$1" | tr -d '[:space:]')"
+if [ "$review_state" = "approved" ] || [ "$review_state" = "merged" ]; then
+  exit 0
+fi
+exit 1
+`,
+        { mode: 0o755 },
+      );
+      await writeFile(
+        join(scriptDir, "check-pr-closed.sh"),
+        "#!/usr/bin/env bash\nexit 1",
+        { mode: 0o755 },
+      );
+      await writeFile(
+        join(workflowDir, "review-routing.yaml"),
+        reviewRoutingWorkflowYaml,
+      );
+
+      const plan = makePlan({ workflow: "review-routing-workflow" });
+      const ticket = makeTicket({
+        workflow: "review-routing-workflow",
+        currentPhase: "await_review",
+        context: {
+          pr_number: "123",
+        },
+      });
+      await savePlan(plan);
+      await saveTicket(ticket);
+    }
+
+    it("routes commented review state into handle_review", async () => {
+      await setupReviewRoutingTest("commented");
+
+      const runner = createRunner(config);
+      const result = await runner.runSingleTicket("test-plan", "TICKET-1");
+
+      expect(result.status).toBe("needs_attention");
+      expect(result.currentPhase).toBe("handle_review");
+      expect(result.context.review_state).toBe("commented\n");
+    });
+
+    it("routes approved review state into await_merge", async () => {
+      await setupReviewRoutingTest("approved");
+
+      const runner = createRunner(config);
+      const result = await runner.runSingleTicket("test-plan", "TICKET-1");
+
+      expect(result.status).toBe("complete");
+      expect(result.currentPhase).toBe("await_merge");
     });
   });
 

--- a/workflows/standard.yaml
+++ b/workflows/standard.yaml
@@ -59,10 +59,20 @@ phases:
     args:
       - "{{ repo }}"
       - "{{ context.pr_number }}"
+    capture:
+      review_state: stdout
     intervalSeconds: 60
     timeoutSeconds: 86400
-    onSuccess: await_merge
+    onSuccess: route_review
     onFailure: route_review_failure
+
+  - id: route_review
+    type: script
+    command: route-review.sh
+    args:
+      - "{{ context.review_state }}"
+    onSuccess: await_merge
+    onFailure: handle_review
 
   - id: route_review_failure
     type: script


### PR DESCRIPTION
## Summary
- treat regular PR conversation comments as actionable review feedback when they arrive after the author's last response activity
- route successful await_review poll results through `route-review.sh` so `commented` enters `handle_review` while approvals still advance to merge
- add script-level coverage for comment detection baselines and runner coverage for the new review-state routing

## Why
Maintainer feedback posted as normal PR conversation comments was being ignored by `await_review`, so tickets could sit idle unless feedback arrived as a formal review or unresolved line-comment thread.

## Validation
- `pnpm run lint:fix`
- `pnpm run typecheck`
- `pnpm run test`

## Ticket
- ORCH-001