### PR TITLE
Mark plan complete when the last ticket finishes

### DIFF
--- a/src/core/runner.test.ts
+++ b/src/core/runner.test.ts
@@ -145,6 +145,37 @@ phases:
     await rm(tmpDir, { recursive: true, force: true });
   });
 
+  async function readPlan(planId: string): Promise<PlanFile> {
+    const path = join(stateDir, "plans", planId, "plan.json");
+    const raw = await readFile(path, "utf-8");
+    return JSON.parse(raw);
+  }
+
+  it("flips plan to complete when the last ticket finishes via runSingleTicket", async () => {
+    await writeFile(
+      join(scriptDir, "run.sh"),
+      '#!/usr/bin/env bash\necho "ok"',
+      { mode: 0o755 },
+    );
+
+    const plan = makePlan({
+      tickets: [
+        { ticketId: "TICKET-1", order: 1, blockedBy: [] },
+        { ticketId: "TICKET-2", order: 2, blockedBy: [] },
+      ],
+    });
+    await savePlan(plan);
+    await saveTicket(makeTicket({ ticketId: "TICKET-1", status: "complete" }));
+    await saveTicket(makeTicket({ ticketId: "TICKET-2", status: "ready" }));
+
+    const runner = createRunner(config);
+    const result = await runner.runSingleTicket("test-plan", "TICKET-2");
+
+    expect(result.status).toBe("complete");
+    const onDiskPlan = await readPlan("test-plan");
+    expect(onDiskPlan.status).toBe("complete");
+  });
+
   it("advances through phases to completion", async () => {
     await writeFile(
       join(scriptDir, "run.sh"),

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -494,6 +494,10 @@ export function createRunner(
       }
     }
 
+    if (current.status === "complete") {
+      await stateManager.maybeMarkPlanComplete(current.planId);
+    }
+
     return current;
   }
 

--- a/src/core/state.test.ts
+++ b/src/core/state.test.ts
@@ -291,6 +291,18 @@ describe("StateManager", () => {
       expect(plan?.status).toBe("active");
     });
 
+    it("does not mark complete when some defined tickets are not yet on disk", async () => {
+      const sm = createStateManager(stateDir);
+      // plan defines t-1 and t-2, but only t-1 has been saved to disk
+      await sm.savePlan(makePlan());
+      await sm.saveTicket(makeTicket({ ticketId: "t-1", status: "complete" }));
+
+      await sm.maybeMarkPlanComplete("plan-1");
+
+      const plan = await sm.getPlan("plan-1");
+      expect(plan?.status).toBe("active");
+    });
+
     it("throws for nonexistent plan", async () => {
       const sm = createStateManager(stateDir);
       await expect(sm.maybeMarkPlanComplete("nope")).rejects.toThrow(

--- a/src/core/state.test.ts
+++ b/src/core/state.test.ts
@@ -212,9 +212,88 @@ describe("StateManager", () => {
       expect(ticket?.status).toBe("queued");
     });
 
+    it("marks plan complete when all tickets are complete", async () => {
+      const sm = createStateManager(stateDir);
+      await sm.savePlan(makePlan());
+      await sm.saveTicket(makeTicket({ ticketId: "t-1", status: "complete" }));
+      await sm.saveTicket(makeTicket({ ticketId: "t-2", status: "complete" }));
+
+      await sm.resolveDependencies("plan-1");
+
+      const plan = await sm.getPlan("plan-1");
+      expect(plan?.status).toBe("complete");
+    });
+
+    it("does not mark plan complete when tickets remain", async () => {
+      const sm = createStateManager(stateDir);
+      await sm.savePlan(makePlan());
+      await sm.saveTicket(makeTicket({ ticketId: "t-1", status: "complete" }));
+      await sm.saveTicket(makeTicket({ ticketId: "t-2", status: "running" }));
+
+      await sm.resolveDependencies("plan-1");
+
+      const plan = await sm.getPlan("plan-1");
+      expect(plan?.status).toBe("active");
+    });
+
     it("throws for nonexistent plan", async () => {
       const sm = createStateManager(stateDir);
       await expect(sm.resolveDependencies("nope")).rejects.toThrow(
+        'Plan "nope" not found',
+      );
+    });
+  });
+
+  describe("maybeMarkPlanComplete", () => {
+    it("marks plan complete when all tickets are complete", async () => {
+      const sm = createStateManager(stateDir);
+      await sm.savePlan(makePlan());
+      await sm.saveTicket(makeTicket({ ticketId: "t-1", status: "complete" }));
+      await sm.saveTicket(makeTicket({ ticketId: "t-2", status: "complete" }));
+
+      await sm.maybeMarkPlanComplete("plan-1");
+
+      const plan = await sm.getPlan("plan-1");
+      expect(plan?.status).toBe("complete");
+    });
+
+    it("does not mark plan complete with partial completion", async () => {
+      const sm = createStateManager(stateDir);
+      await sm.savePlan(makePlan());
+      await sm.saveTicket(makeTicket({ ticketId: "t-1", status: "complete" }));
+      await sm.saveTicket(makeTicket({ ticketId: "t-2", status: "running" }));
+
+      await sm.maybeMarkPlanComplete("plan-1");
+
+      const plan = await sm.getPlan("plan-1");
+      expect(plan?.status).toBe("active");
+    });
+
+    it("is a no-op when plan is already complete", async () => {
+      const sm = createStateManager(stateDir);
+      await sm.savePlan(makePlan({ status: "complete" }));
+      await sm.saveTicket(makeTicket({ ticketId: "t-1", status: "complete" }));
+      await sm.saveTicket(makeTicket({ ticketId: "t-2", status: "complete" }));
+
+      await sm.maybeMarkPlanComplete("plan-1");
+
+      const plan = await sm.getPlan("plan-1");
+      expect(plan?.status).toBe("complete");
+    });
+
+    it("is a no-op when the plan has no tickets", async () => {
+      const sm = createStateManager(stateDir);
+      await sm.savePlan(makePlan({ tickets: [] }));
+
+      await sm.maybeMarkPlanComplete("plan-1");
+
+      const plan = await sm.getPlan("plan-1");
+      expect(plan?.status).toBe("active");
+    });
+
+    it("throws for nonexistent plan", async () => {
+      const sm = createStateManager(stateDir);
+      await expect(sm.maybeMarkPlanComplete("nope")).rejects.toThrow(
         'Plan "nope" not found',
       );
     });

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -22,6 +22,7 @@ export interface StateManager {
   getReadyTickets(): Promise<TicketState[]>;
   getRunningCount(): Promise<number>;
   resolveDependencies(planId: string): Promise<void>;
+  maybeMarkPlanComplete(planId: string): Promise<void>;
 }
 
 async function readJsonSafe<T>(
@@ -197,6 +198,21 @@ export function createStateManager(stateDir: string): StateManager {
             status: "ready",
           });
         }
+      }
+
+      await this.maybeMarkPlanComplete(planId);
+    },
+
+    async maybeMarkPlanComplete(planId) {
+      const plan = await this.getPlan(planId);
+      if (!plan) throw new Error(`Plan "${planId}" not found`);
+      if (plan.status === "complete") return;
+
+      const tickets = await this.listTickets(planId);
+      const allComplete =
+        tickets.length > 0 && tickets.every((t) => t.status === "complete");
+      if (allComplete) {
+        await this.savePlan({ ...plan, status: "complete" });
       }
     },
   };

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -210,7 +210,9 @@ export function createStateManager(stateDir: string): StateManager {
 
       const tickets = await this.listTickets(planId);
       const allComplete =
-        tickets.length > 0 && tickets.every((t) => t.status === "complete");
+        plan.tickets.length > 0 &&
+        tickets.length === plan.tickets.length &&
+        tickets.every((t) => t.status === "complete");
       if (allComplete) {
         await this.savePlan({ ...plan, status: "complete" });
       }


### PR DESCRIPTION
## Problem

Plans never transition to `complete` status. After all tickets finish, the plan stays `active` indefinitely, giving callers no signal that work is done.

## Solution

Extract a `maybeMarkPlanComplete(planId)` method on `StateManager` that marks the plan `complete` when every ticket is complete. Call it in two places:

1. End of `resolveDependencies` — handles the case where the last batch resolves and all tickets were already complete
2. In the runner's `runSingleTicket` after a ticket reaches `complete` — handles the common case of the last ticket finishing

## Test plan

- [x] Marks plan when all tickets are complete
- [x] No-op when tickets remain in progress
- [x] No-op when plan is already complete
- [x] No-op when plan has no tickets
- [x] Throws for nonexistent plan
- [x] `runSingleTicket` flips plan to `complete` when the last ticket finishes